### PR TITLE
Templating / Replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,70 @@ Or define your project in a JSON manifest:
 }
 ```
 
+### Templating & File Replacements
+
+the JSON manifest supports a simple templating system where you must define an
+insertion point (that is simply fed into `string.replace`) as well as a file
+that will be inserted into that template. Templates will not be displayed to the
+user for editing. For example:
+
+`project.json`:
+
+```json
+{
+  "files": {
+    "index.html": {
+      "replacements": {
+        "<!-- dom body -->": "index-dom.html",
+        "<!-- dom head -->": "index-head.html"
+      }
+    },
+    "my-element.js": {}
+  }
+}
+```
+
+Here we define 2 insertion points in `index.html` that will get applied
+sequentially: `<!-- dom body -->` and `<!-- dom head -->` which will be replaced
+with the contents of `index-dom.html` and `index-head.html` respectively.
+
+`index.html`:
+
+```html
+<html>
+  <head>
+    <script src="https://unpkg.com/@webcomponents/webcomponentsjs@2.4.4/webcomponents-loader.js"></script>
+    <!-- dom head -->
+  </head>
+  <body>
+    <div>Here are the contents:</div>
+    <!-- dom body -->
+  </body>
+</html>
+```
+
+`index-head.html`:
+
+```html
+<script type="module" src="./my-element.js"></script>
+```
+
+`index-dom.html`:
+
+```html
+<my-element myNumber="5">
+  <div>Element is not upgraded</div>
+</my-element>
+```
+
+The code sample editor will show a tab for each `index-head.html` and
+`index-dom.html` but hide `index.html` as it is considered a template since
+it has `replacements` defined.
+
+_NB: Replacements apply `string.replace` sequentially to the same string, so
+multiple replacements in the same template may cause unintended behavior if the
+insertion point string is inserted by the user's code._
+
 ## Getting Started
 
 Install with npm:
@@ -100,7 +164,7 @@ npm i code-sample-editor
 Load the component definition:
 ```html
 <script
-  type="module" 
+  type="module"
   src="/node_modules/code-sample-editor/lib/code-sample-editor.js">
 </script>
 ```

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,92 +1,106 @@
 <!DOCTYPE html>
 <html>
-
-<head>
-  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
-  <script src="https://unpkg.com/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-  <script type="module" src="../lib/code-sample-editor.js"></script>
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-    }
-    code-sample-editor {
-      margin-bottom: 48px;
-    }
-  </style>
-</head>
-
-<body>
-  <h2>Inline Sample Files</h2>
-  <p>
-    This editor has no configuration file, just <code>&lt;script></code> tags
-    with type attributes with a "sample/" prefix.
-  </p>
-  <code-sample-editor>
-    <script type="sample/html" filename="index.html">
-<!doctype html>
-<html>
   <head>
-    <script type="module" src="./my-element.js">&lt;/script>
+    <link
+      href="https://fonts.googleapis.com/css?family=Material+Icons&display=block"
+      rel="stylesheet"
+    />
+    <script src="https://unpkg.com/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script type="module" src="../lib/code-sample-editor.js"></script>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+      }
+      code-sample-editor {
+        margin-bottom: 48px;
+      }
+    </style>
   </head>
+
   <body>
-    <div>Here are the contents:</div>
-    <my-element myNumber="5">
-      <div>Element is not upgraded</div>
-    </my-element>
+    <h2>Inline Sample Files</h2>
+    <p>
+      This editor has no configuration file, just <code>&lt;script></code> tags
+      with type attributes with a "sample/" prefix.
+    </p>
+    <code-sample-editor>
+      <script type="sample/html" filename="index.html">
+        <!doctype html>
+        <html>
+          <head>
+            <script type="module" src="./my-element.js">&lt;/script>
+          </head>
+          <body>
+            <div>Here are the contents:</div>
+            <my-element myNumber="5">
+              <div>Element is not upgraded</div>
+            </my-element>
+          </body>
+        </html>
+      </script>
+      <script type="sample/ts" filename="my-element.ts">
+        import { LitElement, html, property, customElement } from 'lit-element';
+        import './my-second-element.js';
+
+        @customElement('my-element')
+        export class MyElement extends LitElement {
+          @property({ type: Number })
+          myNumber?: number;
+
+          render() {
+            return html`
+              <div>Here is ${this.myNumber}</div>
+              <div>And here is my second element:</div>
+              <my-second-element></my-second-element>
+            `;
+          }
+        }
+      </script>
+      <script type="sample/ts" filename="my-second-element.ts">
+        import { LitElement, html, customElement } from 'lit-element';
+
+        @customElement('my-second-element')
+        export class MySecondElement extends LitElement {
+          render() {
+            return html`
+              <div>This is inside the shadow dom of my-second-element</div>
+            `;
+          }
+        }
+      </script>
+    </code-sample-editor>
+
+    <h2>TypeScript</h2>
+    <p>
+      Note that imports to other TypeScript files use the .js extension like you
+      would with tsc.
+    </p>
+    <code-sample-editor
+      project-src="./typescript/project.json"
+    ></code-sample-editor>
+
+    <h2>Basic Project</h2>
+    <p>
+      An index.html and two local .js file, importing an npm package with bare
+      module specifiers.
+    </p>
+    <code-sample-editor
+      project-src="./project-1/project.json"
+    ></code-sample-editor>
+
+    <h2>MWC Demo</h2>
+    <p>A demo for <code>&lt;mwc-button></code>.</p>
+    <code-sample-editor
+      project-src="./mwc-button/project.json"
+    ></code-sample-editor>
+
+    <h2>Replacements</h2>
+    <p>
+      An index.html with two replacement files for the head and the body as well
+      as two js files where there is a replacement for the render method.
+    </p>
+    <code-sample-editor
+      project-src="./replacements/project.json"
+    ></code-sample-editor>
   </body>
-</html>      
-    </script>
-    <script type="sample/ts" filename="my-element.ts">
-import { LitElement, html, property, customElement } from 'lit-element';
-import './my-second-element.js';
-
-@customElement('my-element')
-export class MyElement extends LitElement {
-  @property({ type: Number })
-  myNumber?: number;
-
-  render() {
-    return html`
-      <div>Here is ${this.myNumber}</div>
-      <div>And here is my second element:</div>
-      <my-second-element></my-second-element>
-    `;
-  }
-}      
-    </script>
-    <script type="sample/ts" filename="my-second-element.ts">
-import { LitElement, html, customElement } from 'lit-element';
-
-@customElement('my-second-element')
-export class MySecondElement extends LitElement {
-  render() {
-    return html`
-      <div>This is inside the shadow dom of my-second-element</div>
-    `;
-  }
-}
-    </script>
-  </code-sample-editor>
-
-  <h2>TypeScript</h2>
-  <p>
-    Note that imports to other TypeScript files use the .js extension like
-    you would with tsc.
-  </p>
-  <code-sample-editor project-src="./typescript/project.json"></code-sample-editor>
-
-  <h2>Basic Project</h2>
-  <p>
-    An index.html and two local .js file, importing an npm package with bare
-    module specifiers.
-  </p>
-  <code-sample-editor project-src="./project-1/project.json"></code-sample-editor>
-
-  <h2>MWC Demo</h2>
-  <p>
-    A demo for <code>&lt;mwc-button></code>.
-  </p>
-  <code-sample-editor project-src="./mwc-button/project.json"></code-sample-editor>
-</body>
-
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,106 +1,99 @@
 <!DOCTYPE html>
 <html>
+
+<head>
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
+  <script src="https://unpkg.com/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script type="module" src="../lib/code-sample-editor.js"></script>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+    }
+    code-sample-editor {
+      margin-bottom: 48px;
+    }
+  </style>
+</head>
+
+<body>
+  <h2>Inline Sample Files</h2>
+  <p>
+    This editor has no configuration file, just <code>&lt;script></code> tags
+    with type attributes with a "sample/" prefix.
+  </p>
+  <code-sample-editor>
+    <script type="sample/html" filename="index.html">
+<!doctype html>
+<html>
   <head>
-    <link
-      href="https://fonts.googleapis.com/css?family=Material+Icons&display=block"
-      rel="stylesheet"
-    />
-    <script src="https://unpkg.com/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-    <script type="module" src="../lib/code-sample-editor.js"></script>
-    <style>
-      body {
-        font-family: Arial, sans-serif;
-      }
-      code-sample-editor {
-        margin-bottom: 48px;
-      }
-    </style>
+    <script type="module" src="./my-element.js">&lt;/script>
   </head>
-
   <body>
-    <h2>Inline Sample Files</h2>
-    <p>
-      This editor has no configuration file, just <code>&lt;script></code> tags
-      with type attributes with a "sample/" prefix.
-    </p>
-    <code-sample-editor>
-      <script type="sample/html" filename="index.html">
-        <!doctype html>
-        <html>
-          <head>
-            <script type="module" src="./my-element.js">&lt;/script>
-          </head>
-          <body>
-            <div>Here are the contents:</div>
-            <my-element myNumber="5">
-              <div>Element is not upgraded</div>
-            </my-element>
-          </body>
-        </html>
-      </script>
-      <script type="sample/ts" filename="my-element.ts">
-        import { LitElement, html, property, customElement } from 'lit-element';
-        import './my-second-element.js';
-
-        @customElement('my-element')
-        export class MyElement extends LitElement {
-          @property({ type: Number })
-          myNumber?: number;
-
-          render() {
-            return html`
-              <div>Here is ${this.myNumber}</div>
-              <div>And here is my second element:</div>
-              <my-second-element></my-second-element>
-            `;
-          }
-        }
-      </script>
-      <script type="sample/ts" filename="my-second-element.ts">
-        import { LitElement, html, customElement } from 'lit-element';
-
-        @customElement('my-second-element')
-        export class MySecondElement extends LitElement {
-          render() {
-            return html`
-              <div>This is inside the shadow dom of my-second-element</div>
-            `;
-          }
-        }
-      </script>
-    </code-sample-editor>
-
-    <h2>TypeScript</h2>
-    <p>
-      Note that imports to other TypeScript files use the .js extension like you
-      would with tsc.
-    </p>
-    <code-sample-editor
-      project-src="./typescript/project.json"
-    ></code-sample-editor>
-
-    <h2>Basic Project</h2>
-    <p>
-      An index.html and two local .js file, importing an npm package with bare
-      module specifiers.
-    </p>
-    <code-sample-editor
-      project-src="./project-1/project.json"
-    ></code-sample-editor>
-
-    <h2>MWC Demo</h2>
-    <p>A demo for <code>&lt;mwc-button></code>.</p>
-    <code-sample-editor
-      project-src="./mwc-button/project.json"
-    ></code-sample-editor>
-
-    <h2>Replacements</h2>
-    <p>
-      An index.html with two replacement files for the head and the body as well
-      as two js files where there is a replacement for the render method.
-    </p>
-    <code-sample-editor
-      project-src="./replacements/project.json"
-    ></code-sample-editor>
+    <div>Here are the contents:</div>
+    <my-element myNumber="5">
+      <div>Element is not upgraded</div>
+    </my-element>
   </body>
+</html>
+    </script>
+    <script type="sample/ts" filename="my-element.ts">
+import { LitElement, html, property, customElement } from 'lit-element';
+import './my-second-element.js';
+
+@customElement('my-element')
+export class MyElement extends LitElement {
+  @property({ type: Number })
+  myNumber?: number;
+
+  render() {
+    return html`
+      <div>Here is ${this.myNumber}</div>
+      <div>And here is my second element:</div>
+      <my-second-element></my-second-element>
+    `;
+  }
+}
+    </script>
+    <script type="sample/ts" filename="my-second-element.ts">
+import { LitElement, html, customElement } from 'lit-element';
+
+@customElement('my-second-element')
+export class MySecondElement extends LitElement {
+  render() {
+    return html`
+      <div>This is inside the shadow dom of my-second-element</div>
+    `;
+  }
+}
+    </script>
+  </code-sample-editor>
+
+  <h2>TypeScript</h2>
+  <p>
+    Note that imports to other TypeScript files use the .js extension like
+    you would with tsc.
+  </p>
+  <code-sample-editor project-src="./typescript/project.json"></code-sample-editor>
+
+  <h2>Basic Project</h2>
+  <p>
+    An index.html and two local .js file, importing an npm package with bare
+    module specifiers.
+  </p>
+  <code-sample-editor project-src="./project-1/project.json"></code-sample-editor>
+
+  <h2>MWC Demo</h2>
+  <p>
+    A demo for <code>&lt;mwc-button></code>.
+  </p>
+  <code-sample-editor project-src="./mwc-button/project.json"></code-sample-editor>
+
+  <h2>Replacements</h2>
+  <p>
+    An index.html with two replacement files for the head and the body as well
+    as two js files where there is a replacement for the render method.
+  </p>
+  <code-sample-editor project-src="./replacements/project.json"></code-sample-editor>
+</body>
+
 </html>

--- a/demo/replacements/index-dom.html
+++ b/demo/replacements/index-dom.html
@@ -1,0 +1,3 @@
+<my-element myNumber="5">
+  <div>Element is not upgraded</div>
+</my-element>

--- a/demo/replacements/index-head.html
+++ b/demo/replacements/index-head.html
@@ -1,0 +1,1 @@
+<script type="module" src="./my-element.js"></script>

--- a/demo/replacements/index.html
+++ b/demo/replacements/index.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <script src="https://unpkg.com/@webcomponents/webcomponentsjs@2.4.4/webcomponents-loader.js"></script>
     <!-- dom head -->
   </head>
   <body>

--- a/demo/replacements/index.html
+++ b/demo/replacements/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <!-- dom head -->
+  </head>
+  <body>
+    <div>Here are the contents:</div>
+    <!-- dom body -->
+  </body>
+</html>

--- a/demo/replacements/my-element.js
+++ b/demo/replacements/my-element.js
@@ -1,0 +1,22 @@
+import {LitElement, html} from "https://unpkg.com/lit-element?module";
+import "./my-second-element.js"
+
+class MyElement extends LitElement {
+  static get properties() {
+    return {
+      myNumber: {
+        type: Number
+      }
+    }
+  }
+
+  render () {
+    return html`
+      <div>Here is ${this.myNumber}</div>
+      <div>And here is my second element:</div>
+      <my-second-element></my-second-element>
+    `;
+  }
+}
+
+customElements.define('my-element', MyElement);

--- a/demo/replacements/my-second-element.js
+++ b/demo/replacements/my-second-element.js
@@ -1,0 +1,7 @@
+import {LitElement, html} from 'https://unpkg.com/lit-element?module';
+
+class MySecondElement extends LitElement {
+  /* second element render */
+}
+
+customElements.define('my-second-element', MySecondElement);

--- a/demo/replacements/project.json
+++ b/demo/replacements/project.json
@@ -1,0 +1,16 @@
+{
+  "files": {
+    "index.html": {
+      "replacements": {
+        "<!-- dom body -->": "index-dom.html",
+        "<!-- dom head -->": "index-head.html"
+      }
+    },
+    "my-element.js": {},
+    "my-second-element.js": {
+      "replacements": {
+        "/* second element render */": "second-element-render.js"
+      }
+    }
+  }
+}

--- a/demo/replacements/second-element-render.js
+++ b/demo/replacements/second-element-render.js
@@ -1,0 +1,5 @@
+render () {
+  return html`
+    <div>This is inside the shadow dom of my-second-element</div>
+  `;
+}

--- a/src/lib/project-parser.ts
+++ b/src/lib/project-parser.ts
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {ProjectManifest, SampleFile} from '../shared/worker-api';
+
+export class FileNode {
+  private children = new Map<string, FileNode>();
+  private content_ = '';
+
+  get editableFiles() {
+    if (this.children.size) {
+      return [...this.children.values()];
+    }
+
+    return [this];
+  }
+
+  get content() {
+    if (this.parent) {
+      return this.content_;
+    }
+
+    return this.render();
+  }
+
+  set content(content: string) {
+    this.content_ = content;
+  }
+
+  constructor(
+    public readonly name: string,
+    content: string,
+    private readonly parent: FileNode | null = null,
+    public readonly contentType: string | undefined
+  ) {
+    this.content_ = content;
+  }
+
+  private render() {
+    let renderedContent = this.content_;
+    for (const [insertionPoint, child] of this.children.entries()) {
+      renderedContent = renderedContent.replace(insertionPoint, child.content);
+    }
+
+    return renderedContent;
+  }
+
+  addInsertionPoint(
+    insertionPoint: string,
+    fileName: string,
+    content: string,
+    contentType: string | undefined
+  ) {
+    const child = new FileNode(fileName, content, this, contentType);
+    this.children.set(insertionPoint, child);
+    return child;
+  }
+}
+
+export class CodeSampleEditorProject {
+  private compilableNodes_: FileNode[] = [];
+  readonly ready: Promise<unknown>;
+
+  constructor(manifest?: ProjectManifest, projectUrl?: URL) {
+    if (!manifest || !projectUrl) {
+      this.ready = Promise.resolve();
+      return;
+    }
+
+    this.ready = this.parseManifest(manifest, projectUrl);
+  }
+
+  private async parseManifest(manifest: ProjectManifest, projectUrl: URL) {
+    const filenames = Object.keys(manifest.files || []);
+
+    this.compilableNodes_ = await Promise.all(
+      filenames.map(async (filename) => {
+        const file = await this.fetchFile(filename, projectUrl);
+
+        const rootNode = new FileNode(
+          filename,
+          file.content,
+          null,
+          file.contentType
+        );
+
+        const replacements = manifest.files![filename].replacements;
+        if (replacements) {
+          const insertionPoints = Object.keys(replacements || []);
+
+          for (const insertionPoint of insertionPoints) {
+            const templateName = replacements[insertionPoint];
+            const insertionFile = await this.fetchFile(
+              templateName,
+              projectUrl
+            );
+
+            rootNode.addInsertionPoint(
+              insertionPoint,
+              templateName,
+              insertionFile.content,
+              insertionFile.contentType
+            );
+          }
+        }
+
+        return rootNode;
+      })
+    );
+  }
+
+  private async fetchFile(filename: string, projectUrl: URL) {
+    const fileUrl = new URL(filename, projectUrl);
+    const response = await fetch(fileUrl.href);
+    if (response.status === 404) {
+      throw new Error(`Could not find file ${filename}`);
+    }
+
+    const content = await response.text();
+
+    // Remember the mime type so that the service worker can set it
+    const contentType = response.headers.get('Content-Type') || undefined;
+
+    return {content, contentType};
+  }
+
+  get editableNodes() {
+    const editableFiles: FileNode[] = [];
+
+    for (const rootFile of this.compilableNodes_) {
+      editableFiles.push(...rootFile.editableFiles);
+    }
+
+    return editableFiles;
+  }
+
+  serialize(): SampleFile[] {
+    return this.compilableNodes_.map<SampleFile>((compilableNode) => {
+      return {
+        name: compilableNode.name,
+        content: compilableNode.content,
+        contentType: compilableNode.contentType,
+      };
+    });
+  }
+
+  addFile(name: string, content: string, contentType: string | undefined) {
+    const newFileNode = new FileNode(name, content, null, contentType);
+    this.compilableNodes_.push(newFileNode);
+  }
+
+  getFile(name: string): SampleFile | undefined {
+    const fileNode = this.compilableNodes_.find((f) => f.name === name);
+    if (!fileNode) {
+      return undefined;
+    }
+
+    return {
+      name: fileNode.name,
+      content: fileNode.content,
+      contentType: fileNode.contentType,
+    };
+  }
+}

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -34,9 +34,9 @@ export interface SampleFile {
 }
 
 export interface FileOptions {
-  // This is reserved to indicate if a file is a template, ie it shouldn't be
-  // loaded itself, but copied to create new files. It's currently unused.
-  isTemplate?: boolean;
+  replacements?: {
+    [insertionPointName: string]: string;
+  };
 }
 
 export interface ProjectManifest {


### PR DESCRIPTION
See readme and demo basically:

`project.json`:

```json
{
  "files": {
    "index.html": {
      "replacements": {
        "<!-- dom body -->": "index-dom.html",
        "<!-- dom head -->": "index-head.html"
      }
    },
    "my-element.js": {},
    "my-second-element.js": {
      "replacements": {
        "/* second element render */": "second-element-render.js"
      }
    }
  }
}

```

`index.html` and `my-second-element.js` are considered templates and the keys will be `string.replace`d sequentially and the templates will not be shown to the user but instead the replacement files.

### TODOS

* allow more metadata for replacements
  * display different title
  * give content type for editor but not fetch (fetching `.html$` will insert `<html><body><head>` into editor)
* Non-sequential replacements
* `replaceAll` instead of `replace` once
* no `await` inside `for` loops (required significant refactoring into ugly code)