### PR TITLE
Allow resizing

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -18,11 +18,8 @@ jobs:
       - name: NPM install
         run: npm ci
 
-      - name: Build elements
+      - name: Build
         run: npm run build
-
-      - name: Build configurator
-        run: npm run build:configurator
 
       - name: Deploy to gh-pages
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-## Unreleased
+## [0.1.1] - 2020-10-25
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-## [0.1.1] - 2020-10-25
+## [0.1.1] - 2020-10-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
+## Unreleased
+
+### Added
+
+- Added `--playground-preview-size` CSS custom property to control the initial
+  size of the RHS preview bar in `<playground-ide>`. The LHS editor will take up
+  all additional space. Defaults to `30%`.
+
+- Added `resizable` property/attribute which allows users to click and drag in
+  the space between the LHS editor and RHS preview of `<playground-ide>` to
+  change their relative sizes.
+
 ## [0.1.0] - 2020-10-24
 
 - [**BREAKING**] NPM package and GitHub repo renamed from `code-sample-editor`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Invalid module import paths.
 
+### Changed
+
+- TypeScript decorator runtime is now imported from `tslib` instead of inlined.
+
 ## [0.1.0] - 2020-10-24
 
 - [**BREAKING**] NPM package and GitHub repo renamed from `code-sample-editor`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   the space between the LHS editor and RHS preview of `<playground-ide>` to
   change their relative sizes.
 
+### Fixed
+
+- Invalid module import paths.
+
 ## [0.1.0] - 2020-10-24
 
 - [**BREAKING**] NPM package and GitHub repo renamed from `code-sample-editor`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Invalid module import paths.
+- Reload button icon now respects `--playground-preview-toolbar-foreground-color`.
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "playground-elements",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2885,9 +2885,9 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.7.19",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.7.19.tgz",
-      "integrity": "sha512-0Ur8ZtuRPwJMj4+VjRLqn5z88WXf+2etZhe4dBA6eYFcdviQefb+Vrd59cTk0VXg08NU/BnAMkalCMHI8lig/A==",
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.7.21.tgz",
+      "integrity": "sha512-qEnJdj+6Mdpt5kZwwCqO6PDNXSHNDDOPbnF4pduS3nub1v5GfgZfi8ysZ2DN4Q65WWgx6hz1a237ZETEHZpR0Q==",
       "dev": true
     },
     "escalade": {
@@ -6799,9 +6799,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.0-dev.20201024",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.0-dev.20201024.tgz",
-      "integrity": "sha512-HKsmWNtG4b+LfwAtA+7d7QBylNzX+F6p8CnhSzOQn5wbD0OElSX1RM7QyxA56nQcTgDaiXPhFDu2PQZw0eRlog==",
+      "version": "4.1.0-dev.20201025",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.0-dev.20201025.tgz",
+      "integrity": "sha512-JIYTkDadjkqGl1ZgD9GhoBQdJ8LIDLvUtwqhOC7F8NHwlPSenL6mKDtV3IQ5k18UpBZD+Xwk58ncwU47UyMyxw==",
       "dev": true
     },
     "typical": {
@@ -7120,9 +7120,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.4.tgz",
-      "integrity": "sha512-deLOfD+RvFgrpAmSZgfGdWYE+OKyHcVHaRQ7NphG/63scpRvTHHeQMAxGGvaLVGJ+HYVcCXlzcTK0ZehFf+eHQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
       "dev": true
     },
     "yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,13 @@
       "integrity": "sha512-vd81iIYRzTHxkhOUIO+xb3jtaLLZvK9EMdOvRKL0LHFMvY3+RcopYGoys//mhFAMNifn7Hpdtnav94xMzDJLEA==",
       "requires": {
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/base": {
@@ -75,6 +82,13 @@
       "integrity": "sha512-9yWf9Etb7mzizt4qav7tbd5ayMuD1j/LrTPyZI7Jtnzh8rq7SvnOUC5iKqxMDq5rTFbiGOtCQZlhq3EG///hbw==",
       "requires": {
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/density": {
@@ -89,6 +103,13 @@
       "requires": {
         "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/feature-targeting": {
@@ -137,6 +158,11 @@
           "requires": {
             "@material/feature-targeting": "8.0.0-canary.774dcfc8e.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -149,6 +175,13 @@
         "@material/dom": "=8.0.0-canary.38ef4501f.0",
         "lit-element": "^2.3.0",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/mwc-icon-button": {
@@ -159,6 +192,13 @@
         "@material/mwc-ripple": "0.19.0-canary.615d861d.0",
         "lit-element": "^2.3.0",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/mwc-linear-progress": {
@@ -186,6 +226,11 @@
           "requires": {
             "@material/feature-targeting": "8.0.0-canary.774dcfc8e.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -200,6 +245,13 @@
         "lit-element": "^2.3.0",
         "lit-html": "^1.1.2",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/mwc-tab": {
@@ -214,6 +266,13 @@
         "lit-element": "^2.3.0",
         "lit-html": "^1.1.2",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/mwc-tab-bar": {
@@ -228,6 +287,13 @@
         "@material/tab-bar": "=8.0.0-canary.38ef4501f.0",
         "lit-element": "^2.3.0",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/mwc-tab-indicator": {
@@ -240,6 +306,13 @@
         "lit-element": "^2.3.0",
         "lit-html": "^1.1.2",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/mwc-tab-scroller": {
@@ -252,6 +325,13 @@
         "@material/tab-scroller": "=8.0.0-canary.38ef4501f.0",
         "lit-element": "^2.3.0",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/progress-indicator": {
@@ -260,6 +340,13 @@
       "integrity": "sha512-8lhLJs8uvF24DkY/6n6Zeihew2hqtumCdl0KhLPkONsFlHmzekvJGhyj/ETKj5qTlrxB4x2NCJqfs7D5E9GOiA==",
       "requires": {
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/ripple": {
@@ -273,6 +360,13 @@
         "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
         "@material/theme": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/rtl": {
@@ -296,6 +390,13 @@
         "@material/theme": "8.0.0-canary.38ef4501f.0",
         "@material/typography": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/tab-bar": {
@@ -310,6 +411,13 @@
         "@material/tab": "8.0.0-canary.38ef4501f.0",
         "@material/tab-scroller": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/tab-indicator": {
@@ -322,6 +430,13 @@
         "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
         "@material/theme": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/tab-scroller": {
@@ -335,6 +450,13 @@
         "@material/feature-targeting": "8.0.0-canary.38ef4501f.0",
         "@material/tab": "8.0.0-canary.38ef4501f.0",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@material/theme": {
@@ -1740,6 +1862,14 @@
       "requires": {
         "pascal-case": "^3.1.1",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "camelcase": {
@@ -1757,6 +1887,14 @@
         "no-case": "^3.0.3",
         "tslib": "^1.10.0",
         "upper-case-first": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "caseless": {
@@ -1846,6 +1984,14 @@
         "sentence-case": "^3.0.3",
         "snake-case": "^3.0.3",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "chokidar": {
@@ -2137,6 +2283,14 @@
         "no-case": "^3.0.3",
         "tslib": "^1.10.0",
         "upper-case": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "content-disposition": {
@@ -2563,6 +2717,14 @@
       "requires": {
         "no-case": "^3.0.3",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "download": {
@@ -3436,6 +3598,14 @@
       "requires": {
         "capital-case": "^1.0.3",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "hosted-git-info": {
@@ -4281,6 +4451,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "lowercase-keys": {
@@ -4643,6 +4821,14 @@
       "requires": {
         "lower-case": "^2.0.1",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "node-cleanup": {
@@ -5053,6 +5239,14 @@
       "requires": {
         "dot-case": "^3.0.3",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "parse5": {
@@ -5075,6 +5269,14 @@
       "requires": {
         "no-case": "^3.0.3",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "path-case": {
@@ -5085,6 +5287,14 @@
       "requires": {
         "dot-case": "^3.0.3",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "path-exists": {
@@ -5928,6 +6138,14 @@
         "no-case": "^3.0.3",
         "tslib": "^1.10.0",
         "upper-case-first": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "serialize-javascript": {
@@ -6035,6 +6253,14 @@
       "requires": {
         "dot-case": "^3.0.3",
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "socks": {
@@ -6525,9 +6751,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
     },
     "tsscmp": {
       "version": "1.0.6",
@@ -6643,6 +6869,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "upper-case-first": {
@@ -6652,6 +6886,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playground-elements",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A multi-file code editor component with live preview",
   "homepage": "https://github.com/PolymerLabs/playground-elements#readme",
   "repository": "github:PolymerLabs/playground-elements",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@material/mwc-tab-bar": "=0.19.0-canary.615d861d.0",
     "comlink": "^4.3.0",
     "lit-element": "^2.3.1",
-    "lit-html": "^1.2.1"
+    "lit-html": "^1.2.1",
+    "tslib": "^2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "git clean -dXn | sed 's/^Would remove //' | grep -v node_modules | xargs rm -rf",
     "nuke": "rm -rf node_modules package-lock.json && npm install",
-    "build": "npm run clean && npm run build:lib && npm run bundle",
+    "build": "npm run clean && npm run build:lib && npm run bundle && npm run build:configurator",
     "build:lib": "tsc --build",
     "build:configurator": "rollup -c rollup.config.configurator.js",
     "bundle": "rollup -c rollup.config.js",

--- a/src/configurator/knobs.ts
+++ b/src/configurator/knobs.ts
@@ -166,11 +166,28 @@ export const knobs = [
     default: true,
     section: 'general',
   }),
+  checkbox({
+    id: 'resizable',
+    label: 'Resizable',
+    section: 'general',
+    default: false,
+    htmlAttribute: 'resizable',
+  }),
   color({
     id: 'highlight',
     label: 'Highlight',
     cssProperty: '--playground-highlight-color',
     default: '#6200ee',
+    section: 'general',
+  }),
+  slider({
+    id: 'previewWidth',
+    label: 'Preview width',
+    cssProperty: '--playground-preview-width',
+    formatCss: (val) => `${val}%`,
+    min: 0,
+    max: 100,
+    default: 30,
     section: 'general',
   }),
   slider({

--- a/src/configurator/playground-configurator.ts
+++ b/src/configurator/playground-configurator.ts
@@ -214,8 +214,9 @@ export class PlaygroundConfigurator extends LitElement {
           style="background-color:${this.values.getValue('pageBackground')}"
         >
           <playground-ide
-            theme=${this.values.getValue('theme')}
+            .theme=${this.values.getValue('theme')}
             .lineNumbers=${this.values.getValue('lineNumbers')}
+            .resizable=${this.values.getValue('resizable')}
             project-src="./project/project.json"
           >
           </playground-ide>

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -19,7 +19,7 @@ import {LitElement, customElement, css, property} from 'lit-element';
 // support is available. See
 // https://github.com/lezer-parser/javascript/issues/3. This module sets a
 // `CodeMirror` global.
-import '../_codemirror/codemirror-bundle.js';
+import './_codemirror/codemirror-bundle.js';
 
 // TODO(aomarks) Provide an API for loading these themes dynamically. We can
 // include a bunch of standard themes, but we don't want them to all be included

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -227,7 +227,7 @@ export class PlaygroundIde extends LitElement {
       // Note we set this property on the RHS element instead of the host so
       // that when "resizable" is toggled, we don't reset a host value that the
       // user might have set.
-      this._rhs.style.removeProperty('--playground-preview-width');
+      this._rhs?.style.removeProperty('--playground-preview-width');
     }
     super.update(changedProperties);
   }

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -232,9 +232,9 @@ export class PlaygroundIde extends LitElement {
     super.update(changedProperties);
   }
 
-  private onResizeBarPointerdown(event: PointerEvent) {
+  private onResizeBarPointerdown({pointerId}: PointerEvent) {
     const bar = this._resizeBar;
-    bar.setPointerCapture(event.pointerId);
+    bar.setPointerCapture(pointerId);
 
     const rhsStyle = this._rhs.style;
     const {left: hostLeft, right: hostRight} = this.getBoundingClientRect();
@@ -253,6 +253,7 @@ export class PlaygroundIde extends LitElement {
     bar.addEventListener('pointermove', onPointermove);
 
     const stopDragging = () => {
+      bar.releasePointerCapture(pointerId);
       bar.removeEventListener('pointermove', onPointermove);
       bar.removeEventListener('pointerup', stopDragging);
     };

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -252,12 +252,12 @@ export class PlaygroundIde extends LitElement {
     };
     bar.addEventListener('pointermove', onPointermove);
 
-    const stopDragging = () => {
+    const onPointerup = () => {
       bar.releasePointerCapture(pointerId);
       bar.removeEventListener('pointermove', onPointermove);
-      bar.removeEventListener('pointerup', stopDragging);
+      bar.removeEventListener('pointerup', onPointerup);
     };
-    bar.addEventListener('pointerup', stopDragging);
+    bar.addEventListener('pointerup', onPointerup);
   }
 }
 

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -12,7 +12,16 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {LitElement, html, customElement, css, property} from 'lit-element';
+import {
+  LitElement,
+  html,
+  customElement,
+  css,
+  query,
+  property,
+  PropertyValues,
+} from 'lit-element';
+import {nothing} from 'lit-html';
 
 import './playground-project.js';
 import './playground-file-editor.js';
@@ -66,13 +75,14 @@ export class PlaygroundIde extends LitElement {
     :host {
       display: flex;
       height: 350px;
-      min-width: 300px;
+      min-width: 200px;
       border: var(--playground-border, solid 1px #ddd);
     }
 
     playground-file-editor {
       height: 100%;
-      width: 70%;
+      flex: 1;
+      min-width: 100px;
       overflow: hidden;
       border-radius: inherit;
       border-top-right-radius: 0;
@@ -80,9 +90,16 @@ export class PlaygroundIde extends LitElement {
       border-right: var(--playground-border, solid 1px #ddd);
     }
 
+    #rhs {
+      height: 100%;
+      width: max(100px, var(--playground-preview-width, 30%));
+      position: relative;
+      border-radius: inherit;
+    }
+
     playground-preview {
       height: 100%;
-      width: 30%;
+      width: 100%;
       border-radius: inherit;
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
@@ -90,6 +107,30 @@ export class PlaygroundIde extends LitElement {
 
     slot {
       display: none;
+    }
+
+    #resizeBar {
+      position: absolute;
+      top: 0;
+      left: -5px;
+      width: 10px;
+      height: 100%;
+      z-index: 9;
+      cursor: col-resize;
+    }
+
+    #resizeOverlay {
+      display: none;
+    }
+    #resizeOverlay.resizing {
+      display: block;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      z-index: 99999;
+      cursor: col-resize;
     }
   `;
 
@@ -121,10 +162,23 @@ export class PlaygroundIde extends LitElement {
   lineNumbers = false;
 
   /**
+   * If true, allow the user to change the relative size of the LHS editor and
+   * RHS preview by clicking and dragging in the space between them.
+   */
+  @property({type: Boolean})
+  resizable = false;
+
+  /**
    * The CodeMirror theme to load.
    */
   @property()
   theme = 'default';
+
+  @query('#resizeOverlay')
+  private _resizeOverlay!: HTMLDivElement;
+
+  @query('#rhs')
+  private _rhs!: HTMLDivElement;
 
   render() {
     const projectId = 'project';
@@ -147,16 +201,66 @@ export class PlaygroundIde extends LitElement {
       >
       </playground-file-editor>
 
-      <playground-preview
-        part="preview"
-        exportparts="preview-toolbar,
-                     preview-location,
-                     preview-reload-button,
-                     preview-loading-indicator"
-        location="Result"
-        .project=${projectId}
-      ></playground-preview>
+      <div id="rhs">
+        ${this.resizable
+          ? html`<div
+                id="resizeBar"
+                @mousedown=${this.onResizeBarMousedown}
+              ></div>
+              <div id="resizeOverlay"></div>`
+          : nothing}
+
+        <playground-preview
+          part="preview"
+          exportparts="preview-toolbar,
+                       preview-location,
+                       preview-reload-button,
+                       preview-loading-indicator"
+          location="Result"
+          .project=${projectId}
+        ></playground-preview>
+      </div>
     `;
+  }
+
+  async update(changedProperties: PropertyValues<this>) {
+    super.update(changedProperties);
+    if (changedProperties.has('resizable') && this.resizable === false) {
+      // Note we set this property on the RHS element instead of the host so
+      // that when "resizable" is toggled, we don't reset a host value that the
+      // user might have set.
+      this._rhs.style.removeProperty('--playground-preview-width');
+    }
+  }
+
+  private onResizeBarMousedown() {
+    const rhsStyle = this._rhs.style;
+    const overlay = this._resizeOverlay;
+    overlay.classList.add('resizing');
+
+    const {left: hostLeft, right: hostRight} = this.getBoundingClientRect();
+    const hostWidth = hostRight - hostLeft;
+    const rhsMinWidth = 100;
+    const rhsMaxWidth = hostWidth - 100;
+
+    const onMousemove = (event: MouseEvent) => {
+      const rhsWidth = Math.min(
+        rhsMaxWidth,
+        Math.max(rhsMinWidth, hostRight - event.clientX)
+      );
+      const percent = (rhsWidth / hostWidth) * 100;
+      rhsStyle.setProperty('--playground-preview-width', `${percent}%`);
+    };
+    overlay.addEventListener('mousemove', onMousemove);
+
+    const stopDragging = () => {
+      overlay.classList.remove('resizing');
+      overlay.removeEventListener('mousemove', onMousemove);
+      overlay.removeEventListener('mouseup', stopDragging);
+      overlay.removeEventListener('mouseout', stopDragging);
+    };
+    overlay.addEventListener('mouseup', stopDragging);
+    overlay.addEventListener('mouseout', stopDragging);
   }
 }
 

--- a/src/playground-preview.ts
+++ b/src/playground-preview.ts
@@ -67,7 +67,6 @@ export class PlaygroundPreview extends LitElement {
     }
 
     #reload-button {
-      color: #444;
       --mdc-icon-button-size: 30px;
       --mdc-icon-size: 18px;
     }

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -30,8 +30,8 @@ import {
   ESTABLISH_HANDSHAKE,
   HANDSHAKE_RECEIVED,
   TypeScriptWorkerAPI,
-} from '../shared/worker-api.js';
-import {getRandomString, endWithSlash} from '../shared/util.js';
+} from './shared/worker-api.js';
+import {getRandomString, endWithSlash} from './shared/util.js';
 import {PlaygroundPreview} from './playground-preview.js';
 import './playground-file-editor.js';
 import {PlaygroundFileEditor} from './playground-file-editor.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "importHelpers": true
   },
   "include": ["src/**/*.ts", "src/lib/worker-api.ts", "src/shared/util.ts"],
   "exclude": ["src/service-worker", "src/shared", "src/typescript-worker"],


### PR DESCRIPTION
- Added `--playground-preview-size` CSS custom property to control the initial size of the RHS preview panel in `<playground-ide>`. The LHS editor will take up all additional space. Defaults to `30%`.

- Added `resizable` property/attribute which allows users to click and drag in the space between the LHS editor and RHS preview of `<playground-ide>` to change their relative sizes.

- **Try it out at https://polymerlabs.github.io/playground-elements/?resizable=y**

Also:
- Fix some invalid module import paths.
- TypeScript decorator runtime is now imported from `tslib` instead of inlined.
- Fix reload button not respecting `--playground-preview-toolbar-foreground-color`.
- Prepare `v0.1.1` release.

![image](https://user-images.githubusercontent.com/48894/97111728-bc507c80-169d-11eb-92b2-d7f099406d3d.png)

Fixes https://github.com/PolymerLabs/playground-elements/issues/60
Fixes https://github.com/PolymerLabs/playground-elements/issues/62