### PR TITLE
Use Puppeteer instead of Playwright for Firefox tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1119,6 +1119,18 @@
         "playwright": "^1.4.2"
       }
     },
+    "@web/test-runner-puppeteer": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-puppeteer/-/test-runner-puppeteer-0.7.2.tgz",
+      "integrity": "sha512-BWnK1GGKNwacZ6IGPxozlgv8pE8WAEEq4YMO4BqkvSzm2013NVsso8Io3nRztowZqkt7u+mRZWYQMBTiQyTKGQ==",
+      "dev": true,
+      "requires": {
+        "@types/puppeteer": "^3.0.1",
+        "@web/test-runner-chrome": "^0.7.2",
+        "@web/test-runner-core": "^0.8.4",
+        "puppeteer": "^5.3.1"
+      }
+    },
     "@web/test-runner-saucelabs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@web/test-runner-saucelabs/-/test-runner-saucelabs-0.1.1.tgz",
@@ -5603,6 +5615,43 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "puppeteer": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.4.1.tgz",
+      "integrity": "sha512-8u6r9tFm3gtMylU4uCry1W/CeAA8uczKMONvGvivkTsGqKA7iB7DWO2CBFYlB9GY6/IEoq9vkI5slJWzUBkwNw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "devtools-protocol": "0.0.809251",
+        "extract-zip": "^2.0.0",
+        "https-proxy-agent": "^4.0.0",
+        "node-fetch": "^2.6.1",
+        "pkg-dir": "^4.2.0",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "puppeteer-core": {
       "version": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "module": "playground-ide.js",
   "main": "playground-ide.js",
   "scripts": {
+    "postinstall": "cd node_modules/puppeteer && PUPPETEER_PRODUCT=firefox node install.js",
     "clean": "git clean -dXn | sed 's/^Would remove //' | grep -v node_modules | xargs rm -rf",
     "nuke": "rm -rf node_modules package-lock.json && npm install",
     "build": "npm run clean && npm run build:themes && npm run build:lib && npm run bundle && npm run build:configurator",
@@ -32,6 +33,7 @@
     "@web/dev-server": "0.0.15",
     "@web/test-runner": "^0.9.4",
     "@web/test-runner-playwright": "^0.6.0",
+    "@web/test-runner-puppeteer": "^0.7.2",
     "clean-css": "^4.2.3",
     "codemirror": "^5.58.1",
     "codemirror-grammar-mode": "^0.1.10",

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -13,6 +13,7 @@
  */
 
 import {playwrightLauncher} from '@web/test-runner-playwright';
+import {puppeteerLauncher} from '@web/test-runner-puppeteer';
 
 // https://modern-web.dev/docs/test-runner/cli-and-configuration/
 export default {
@@ -22,11 +23,19 @@ export default {
   nodeResolve: true,
   browsers: [
     playwrightLauncher({product: 'chromium'}),
-    // TODO(aomarks) Firefix is flaky, with service worker 404s. Probably needs
-    // to be addressed as part of
-    // https://github.com/PolymerLabs/playground-elements/issues/39
-    // playwrightLauncher({product: 'firefox'}),
     playwrightLauncher({product: 'webkit'}),
+    // Playwright Firefox does not seem to work at all with Service Workers. The
+    // issue can be reproduced by launching Firefox with flag "-juggler 0". So
+    // for now we'll use Puppeteer for Firefox.
+    //
+    // Also note we can't use Puppeteer for both Chromium and Firefox, because
+    // only one or the other can be installed at once (see our "postinstall" NPM
+    // script). See
+    // https://modern-web.dev/docs/test-runner/browser-launchers/puppeteer/.
+    //
+    // TODO(aomarks) Look into this a little more and file an issue on
+    // Playwright (or Firefox).
+    puppeteerLauncher({launchOptions: {product: 'firefox'}}),
   ],
   browserStartTimeout: 30000, // default 30000
   testsStartTimeout: 20000, // default 10000


### PR DESCRIPTION
This makes Firefox tests pass (at least _sometimes_). It seems that the `-juggler 0` flag that Playwright passes to Firefox makes Service Workers break in some way, so the Firefox failures were actually unrelated to the flakiness we see generally. I don't know if this is a bug in Firefox or Playwright. I'm looking at finding repros and fixes for the general flakiness next.