### PR TITLE
fix(preview): Safari scrolling bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -->
 
 <!-- ## [X.Y.Z] - YYYY-MM-DD -->
-<!-- ## Unreleased -->
+## Unreleased
+
 <!-- ### Changed -->
+
 <!-- ### Added -->
-<!-- ### Fixed -->
+
+### Fixed
+
+- Fix Safari scrolling bug by limiting preview max-height
+
 <!-- ### Removed -->
 
 ## [0.3.2] - 2020-11-30

--- a/src/playground-preview.ts
+++ b/src/playground-preview.ts
@@ -69,6 +69,7 @@ export class PlaygroundPreview extends LitElement {
     }
 
     #content {
+      max-height: 100%;
       position: relative;
       flex: 1;
     }


### PR DESCRIPTION
For some reason, in Safari, if the rendered content in the iframe has `height: 100vh` every time you interact with the code on the left, the right side preview continues to grow.