### PR TITLE
Fix project fetch race conditions, and handle service worker termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The playground service worker now serves its own 404s when a file is not
   found, instead of forwarding the request to the server.
 
+### Fixed
+
+- Fix race condition where preview could load too early and 404.
+- Fix race condition where preview could sometimes never load.
+
 ## [0.3.3] - 2020-12-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
+## Unreleased
+
+### Changed
+
+- The playground service worker now serves its own 404s when a file is not
+  found, instead of forwarding the request to the server.
+
 ## [0.3.3] - 2020-12-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix race condition where preview could load too early and 404.
 - Fix race condition where preview could sometimes never load.
+- Fix preview 404 that could occur after leaving page idle for some time.
 
 ## [0.3.3] - 2020-12-01
 

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -152,8 +152,10 @@ export class PlaygroundProject extends LitElement {
   }
 
   private get _serviceWorkerProxyIframeUrl() {
+    // We include the session ID as a query parameter so that the service worker
+    // can figure out which proxy client goes with which session.
     return new URL(
-      'playground-service-worker-proxy.html',
+      `playground-service-worker-proxy.html?playground-session-id=${this._sessionId}`,
       this._normalizedSandboxBaseUrl
     ).href;
   }

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -171,7 +171,10 @@ export class PlaygroundProject extends LitElement {
         editor.files = this._files;
       }
     }
-    if (changedProperties.has('_serviceWorkerAPI')) {
+    if (
+      changedProperties.has('_serviceWorkerAPI') ||
+      changedProperties.has('_files')
+    ) {
       const previewSrc = this._previewSrc;
       for (const preview of this._previews) {
         preview.src = previewSrc;
@@ -191,12 +194,15 @@ export class PlaygroundProject extends LitElement {
   }
 
   private _slotChange(_e: Event) {
+    if (this.projectSrc) {
+      // Note that the slotchange event will fire even if the only child is
+      // whitespace.
+      return;
+    }
     const elements = this._slot.assignedElements({flatten: true});
     const sampleScripts = elements.filter((e) =>
       e.matches('script[type^=sample][filename]')
     );
-    // TODO (justinfagnani): detect both inline samples and a manifest
-    // and give an warning.
     this._files = sampleScripts.map((s) => {
       const typeAttr = s.getAttribute('type');
       const fileType = typeAttr!.substring('sample/'.length);

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -272,8 +272,8 @@ export class PlaygroundProject extends LitElement {
     // This iframe exists to proxy messages between this project and the service
     // worker, because the service worker may be running on a different origin
     // for security.
-    const window = this._iframe.contentWindow;
-    if (!window) {
+    const iframeWindow = this._iframe.contentWindow;
+    if (!iframeWindow) {
       throw new Error(
         'Unexpected internal error: ' +
           '<playground-project> service worker proxy iframe had no contentWindow'
@@ -296,7 +296,7 @@ export class PlaygroundProject extends LitElement {
     // `this._normalizedSandboxBaseUrl.origin`, but unclear if that provides any
     // security benefit, and would add the limitation that the sandboxBaseUrl
     // can't redirect to another origin.
-    window.postMessage(initMessage, '*', [initMessage.port]);
+    iframeWindow.postMessage(initMessage, '*', [initMessage.port]);
   }
 
   private _onNewServiceWorkerPort(port: MessagePort) {

--- a/src/playground-service-worker-proxy.ts
+++ b/src/playground-service-worker-proxy.ts
@@ -12,13 +12,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {ESTABLISH_HANDSHAKE} from './shared/worker-api.js';
-
-export interface ProxyInitMessage {
-  port: MessagePort;
-  url: string;
-  scope: string;
-}
+import {
+  PlaygroundMessage,
+  CONNECT_SW_TO_PROJECT,
+  CONNECT_PROJECT_TO_SW,
+  CONFIGURE_PROXY,
+} from './shared/worker-api.js';
 
 (async () => {
   try {
@@ -35,15 +34,19 @@ export interface ProxyInitMessage {
   // Wait for our parent to send us:
   // 1. The URL and scope of the Service Worker to register.
   // 2. A MessagePort, on which we'll forward up new Service Worker ports.
-  const {url, scope, port: parentPort} = await new Promise<ProxyInitMessage>(
-    (resolve) => {
-      const listener = (event: MessageEvent<ProxyInitMessage>) => {
+  const {url, scope, port: parentPort} = await new Promise<{
+    url: string;
+    scope: string;
+    port: MessagePort;
+  }>((resolve) => {
+    const listener = (event: MessageEvent<PlaygroundMessage>) => {
+      if (event.data.type === CONFIGURE_PROXY) {
         window.removeEventListener('message', listener);
         resolve(event.data);
-      };
-      window.addEventListener('message', listener);
-    }
-  );
+      }
+    };
+    window.addEventListener('message', listener);
+  });
 
   const registration = await navigator.serviceWorker.register(
     new URL(url, import.meta.url).href,
@@ -52,8 +55,18 @@ export interface ProxyInitMessage {
 
   const connect = (sw: ServiceWorker) => {
     const {port1, port2} = new MessageChannel();
-    parentPort.postMessage(port1, [port1]);
-    sw.postMessage({initComlink: ESTABLISH_HANDSHAKE, port: port2}, [port2]);
+
+    const projectMessage: PlaygroundMessage = {
+      type: CONNECT_PROJECT_TO_SW,
+      port: port1,
+    };
+    parentPort.postMessage(projectMessage, [projectMessage.port]);
+
+    const swMessage: PlaygroundMessage = {
+      type: CONNECT_SW_TO_PROJECT,
+      port: port2,
+    };
+    sw.postMessage(swMessage, [swMessage.port]);
   };
 
   registration.addEventListener('updatefound', () => {

--- a/src/playground-service-worker-proxy.ts
+++ b/src/playground-service-worker-proxy.ts
@@ -17,6 +17,7 @@ import {
   CONNECT_SW_TO_PROJECT,
   CONNECT_PROJECT_TO_SW,
   CONFIGURE_PROXY,
+  MISSING_FILE_API,
 } from './shared/worker-api.js';
 
 (async () => {
@@ -76,6 +77,19 @@ import {
       connect(registration.installing);
     }
   });
+
+  navigator.serviceWorker.addEventListener(
+    'message',
+    (event: MessageEvent<PlaygroundMessage>) => {
+      if (event.data.type === MISSING_FILE_API && registration.active) {
+        // A fetch was made for a session that the service worker doesn't have a
+        // file API for. Most likely the service worker was stopped and lost its
+        // state, as can happen at any time. The fetch re-awakened it, and now
+        // the fetch is waiting for us to re-connect.
+        connect(registration.active);
+      }
+    }
+  );
 
   if (registration.active) {
     connect(registration.active);

--- a/src/service-worker/playground-service-worker.ts
+++ b/src/service-worker/playground-service-worker.ts
@@ -13,8 +13,9 @@
  */
 
 import {
-  HANDSHAKE_RECEIVED,
-  ESTABLISH_HANDSHAKE,
+  ACKNOWLEDGE_SW_CONNECTION,
+  CONNECT_SW_TO_PROJECT,
+  PlaygroundMessage,
   ServiceWorkerAPI,
   FileAPI,
 } from '../shared/worker-api.js';
@@ -99,12 +100,13 @@ const onActivate = (event: ExtendableEvent) => {
   event.waitUntil(self.clients.claim());
 };
 
-const onMessage = (e: ExtendableMessageEvent) => {
+const onMessage = (
+  e: Omit<ExtendableMessageEvent, 'data'> & {data: PlaygroundMessage}
+) => {
   // Receive a handshake message from a page and setup Comlink.
-  if (e.data.initComlink === ESTABLISH_HANDSHAKE) {
-    (e.data.port as MessagePort).postMessage({
-      initComlink: HANDSHAKE_RECEIVED,
-    });
+  if (e.data.type === CONNECT_SW_TO_PROJECT) {
+    const ack: PlaygroundMessage = {type: ACKNOWLEDGE_SW_CONNECTION};
+    e.data.port.postMessage(ack);
     expose(workerAPI, e.data.port);
   }
 };

--- a/src/service-worker/playground-service-worker.ts
+++ b/src/service-worker/playground-service-worker.ts
@@ -39,7 +39,7 @@ const workerAPI: ServiceWorkerAPI = {
  * keyed by session ID.
  */
 const fileAPIs = new Map<SessionID, FileAPI>();
-const getFile = async (e: FetchEvent, path: string, sessionId: SessionID) => {
+const getFile = async (_e: FetchEvent, path: string, sessionId: SessionID) => {
   const fileAPI = fileAPIs.get(sessionId);
   if (fileAPI) {
     const file = await fileAPI.getFile(path);
@@ -52,7 +52,10 @@ const getFile = async (e: FetchEvent, path: string, sessionId: SessionID) => {
   } else {
     console.warn(`No FileAPI for session ${sessionId}`);
   }
-  return fetch(e.request);
+  // Don't delegate to a server fetch. We know this request was within our
+  // scope, so it's in our virtual filesystem, and we're within our rights to
+  // force a 404 here. Who knows what the server would respond with.
+  return new Response('404 playground file not found', {status: 404});
 };
 
 const onFetch = (e: FetchEvent) => {

--- a/src/shared/deferred.ts
+++ b/src/shared/deferred.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+export class Deferred<T> {
+  readonly promise: Promise<T>;
+  private _resolve!: (value: T) => void;
+  resolved = false;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve) => {
+      this._resolve = resolve;
+    });
+  }
+
+  resolve(value: T) {
+    this.resolved = true;
+    this._resolve(value);
+  }
+}

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -36,6 +36,12 @@ export const CONNECT_PROJECT_TO_SW = 3;
  */
 export const ACKNOWLEDGE_SW_CONNECTION = 4;
 
+/**
+ * Sent from the service worker to the proxy, to notify when a file API is
+ * missing and hence a re-connection is probably required.
+ */
+export const MISSING_FILE_API = 5;
+
 export type PlaygroundMessage =
   | {
       type: typeof CONFIGURE_PROXY;
@@ -53,6 +59,9 @@ export type PlaygroundMessage =
     }
   | {
       type: typeof ACKNOWLEDGE_SW_CONNECTION;
+    }
+  | {
+      type: typeof MISSING_FILE_API;
     };
 
 export interface ServiceWorkerAPI {

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -12,8 +12,48 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-export const ESTABLISH_HANDSHAKE = 1;
-export const HANDSHAKE_RECEIVED = 2;
+/**
+ * Sent from the project to the proxy, with configuration and a port for further
+ * messages.
+ */
+export const CONFIGURE_PROXY = 1;
+
+/**
+ * Sent from the proxy to the service worker, with a port that will be connected
+ * to the project.
+ */
+export const CONNECT_SW_TO_PROJECT = 2;
+
+/**
+ * Sent from the proxy to the project, with a port that will be connected to the
+ * service worker.
+ */
+export const CONNECT_PROJECT_TO_SW = 3;
+
+/**
+ * Sent from the service worker to the project, to confirm that the port was
+ * received.
+ */
+export const ACKNOWLEDGE_SW_CONNECTION = 4;
+
+export type PlaygroundMessage =
+  | {
+      type: typeof CONFIGURE_PROXY;
+      url: string;
+      scope: string;
+      port: MessagePort;
+    }
+  | {
+      type: typeof CONNECT_SW_TO_PROJECT;
+      port: MessagePort;
+    }
+  | {
+      type: typeof CONNECT_PROJECT_TO_SW;
+      port: MessagePort;
+    }
+  | {
+      type: typeof ACKNOWLEDGE_SW_CONNECTION;
+    };
 
 export interface ServiceWorkerAPI {
   setFileAPI(fileAPI: FileAPI, sessionID: string): void;

--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -13,7 +13,7 @@ export default {
         ) {
           return {
             body: ctx.body.replace(
-              /\n\n<!-- injected by web-dev-server.*<\/script>\n\n/gs,
+              /<!-- injected by web-dev-server.*<\/script>/gs,
               ''
             ),
           };


### PR DESCRIPTION
- Fix race condition that caused preview to 404. Occurred when `project-src` was set, plus any child was slotted _even if only whitespace_, and the project files fetch took longer than the service worker handshake.

- Fix race condition that caused preview to never load. Occured when `project-src` was set, with no slotted child, and the project files fetch took longer than the service worker handshake.

- Handle service worker terminations. Service workers are allowed to terminate anytime but this doesn't count as a state change, so we weren't noticing it before. Any fetch/message event wakes the service worker up again, however it will have lost all of its state, which includes our file APIs. We now detect when this has happened, send a postMessage to request a reconnect, and block fetch responses until we receive the file API.

Also:

- Serve our own 404s instead of forwarding to the server. Since we know we're serving the virtual file system based on the URL, there's no reason to fallback to the server. There's no guarantee the server will return a 404, plus even if it does, it doesn't make sense to display the 404 in the style of the server.

- Refactor post messages to be more strongly typed and easier to follow.

- Strip web-dev-server reload inject script more reliably (it changed recently).

Hopefully fixes https://github.com/PolymerLabs/playground-elements/issues/39
Hopefully fixes https://github.com/PolymerLabs/playground-elements/issues/85