### PR TITLE
Support import maps, and resolve .js files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
+## Unreleased
+
+### Fixed
+
+- Bare module imports in `.js` files are now resolved to unpkg.com URLs just
+  like `.ts` files.
+
 ## [0.4.1] - 2021-01-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,63 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Import maps are now supported. This allows customizing the URL that a bare
+  module specifier resolves to, e.g. to a specific version, or to a different
+  CDN.
+
+  Note that import maps currently only apply to the _immediate imports of
+  project source files_, not to external transitive dependencies.
+
+  Also note `scopes` are not yet supported, only `imports`.
+
+  See https://github.com/WICG/import-maps and
+  https://wicg.github.io/import-maps/ for more information on import maps.
+
+  Previously, all bare modules resolved to unpkg.com URLs at the latest version.
+  This continues to be the fallback behavior if no import map is provided, or no
+  entry in it matches.
+
+  To specify an import map in a JSON project manifest, add an `importMap`
+  property:
+
+  ```json
+  {
+    "files": {
+      "index.html": {},
+      "my-element.ts": {}
+    },
+    "importMap": {
+      "imports": {
+        "lit-html": "https://unpkg.com/lit-html@next-major",
+        "lit-html/": "https://unpkg.com/lit-html@next-major/"
+      }
+    }
+  }
+  ```
+
+  To specify an import map inline, add a `<script type="sample/importmap">`
+  slotted child:
+
+  ```html
+  <playground-ide>
+    <script type="sample/importmap">
+      {
+        "imports": {
+          "lit-html": "https://unpkg.com/lit-html@next-major",
+          "lit-html/": "https://unpkg.com/lit-html@next-major/"
+        }
+      }
+    </script>
+    ...
+  </playground-ide>
+  ```
+
 ### Fixed
 
-- Bare module imports in `.js` files are now resolved to unpkg.com URLs just
-  like `.ts` files.
+- Bare module imports in `.js` files are now resolved in the same way as `.ts`
+  files.
 
 ## [0.4.1] - 2021-01-15
 

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -71,7 +71,7 @@ export interface ServiceWorkerAPI {
 export interface TypeScriptWorkerAPI {
   compileProject(
     files: Array<SampleFile>,
-    importMap?: ModuleImportMap
+    importMap: ModuleImportMap
   ): Promise<Map<string, string>>;
 }
 

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -69,7 +69,10 @@ export interface ServiceWorkerAPI {
 }
 
 export interface TypeScriptWorkerAPI {
-  compileProject(files: Array<SampleFile>): Promise<Map<string, string>>;
+  compileProject(
+    files: Array<SampleFile>,
+    importMap?: ModuleImportMap
+  ): Promise<Map<string, string>>;
 }
 
 export interface FileAPI {
@@ -97,4 +100,10 @@ export interface FileOptions {
 
 export interface ProjectManifest {
   files?: {[filename: string]: FileOptions};
+  importMap?: ModuleImportMap;
+}
+
+export interface ModuleImportMap {
+  imports?: {[name: string]: string};
+  // No scopes for now.
 }

--- a/src/typescript-worker/playground-typescript-worker.ts
+++ b/src/typescript-worker/playground-typescript-worker.ts
@@ -69,8 +69,8 @@ const workerAPI: TypeScriptWorkerAPI = {
    * multiple <playground-project> instances to save memory and type analysis of
    * common lib files like lit-element, lib.d.ts and dom.d.ts.
    */
-  async compileProject(files: Array<SampleFile>, importMap?: ModuleImportMap) {
-    const moduleResolver = new ModuleResolver(importMap ?? {});
+  async compileProject(files: Array<SampleFile>, importMap: ModuleImportMap) {
+    const moduleResolver = new ModuleResolver(importMap);
     const loadedFiles = await loadFiles(files, moduleResolver);
     const languageServiceHost = new WorkerLanguageServiceHost(
       loadedFiles,

--- a/src/typescript-worker/playground-typescript-worker.ts
+++ b/src/typescript-worker/playground-typescript-worker.ts
@@ -12,7 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {TypeScriptWorkerAPI, SampleFile} from '../shared/worker-api.js';
+import {
+  TypeScriptWorkerAPI,
+  SampleFile,
+  ModuleImportMap,
+} from '../shared/worker-api.js';
 import {expose} from 'comlink';
 import * as ts from 'typescript';
 
@@ -34,12 +38,13 @@ const compilerOptions = {
  * rewrites ourselves to ensure less module duplication.
  */
 const makeBareSpecifierTransformVisitor = (
-  context: ts.TransformationContext
+  context: ts.TransformationContext,
+  moduleResolver: ModuleResolver
 ): ts.Visitor => {
   const visitor: ts.Visitor = (node) => {
     if (ts.isImportDeclaration(node)) {
       const specifier = (node.moduleSpecifier as ts.StringLiteral).text;
-      const {type, url} = resolveSpecifier(specifier, self.origin);
+      const {type, url} = moduleResolver.resolve(specifier, self.origin);
       if (type === 'bare') {
         const newNode = ts.getMutableClone(node);
         (newNode as {
@@ -53,14 +58,6 @@ const makeBareSpecifierTransformVisitor = (
   return visitor;
 };
 
-const transformers: ts.CustomTransformers = {
-  after: [
-    (context: ts.TransformationContext) => <T extends ts.Node>(node: T) => {
-      return ts.visitNode(node, makeBareSpecifierTransformVisitor(context));
-    },
-  ],
-};
-
 const workerAPI: TypeScriptWorkerAPI = {
   /**
    * Compiles a project, returning a Map of compiled file contents. The map only
@@ -72,8 +69,9 @@ const workerAPI: TypeScriptWorkerAPI = {
    * multiple <playground-project> instances to save memory and type analysis of
    * common lib files like lit-element, lib.d.ts and dom.d.ts.
    */
-  async compileProject(files: Array<SampleFile>) {
-    const loadedFiles = await loadFiles(files);
+  async compileProject(files: Array<SampleFile>, importMap?: ModuleImportMap) {
+    const moduleResolver = new ModuleResolver(importMap ?? {});
+    const loadedFiles = await loadFiles(files, moduleResolver);
     const languageServiceHost = new WorkerLanguageServiceHost(
       loadedFiles,
       self.origin,
@@ -85,6 +83,16 @@ const workerAPI: TypeScriptWorkerAPI = {
     );
     const program = languageService.getProgram();
     const emittedFiles = new Map<string, string>();
+    const transformers: ts.CustomTransformers = {
+      after: [
+        (context: ts.TransformationContext) => <T extends ts.Node>(node: T) => {
+          return ts.visitNode(
+            node,
+            makeBareSpecifierTransformVisitor(context, moduleResolver)
+          );
+        },
+      ],
+    };
     for (const file of files) {
       if (file.name.endsWith('.ts') || file.name.endsWith('.js')) {
         const url = new URL(file.name, self.origin).href;
@@ -135,7 +143,8 @@ type FileRecord = PendingFileRecord | ResolvedFileRecord | RedirectedFileRecord;
  * checking we will load the entire module graph here.
  */
 const loadFiles = (
-  files: Array<SampleFile>
+  files: Array<SampleFile>,
+  moduleResolver: ModuleResolver
 ): Promise<Map<string, FileRecord>> => {
   return new Promise(async (resolve, _reject) => {
     const fileRecords = new Map<string, FileRecord>();
@@ -187,7 +196,7 @@ const loadFiles = (
 
         for (const importedFile of preProcessedFile.importedFiles) {
           const specifier = importedFile.fileName;
-          const {type, url} = resolveSpecifier(specifier, referrerUrl);
+          const {type, url} = moduleResolver.resolve(specifier, referrerUrl);
 
           if (!fileRecords.has(url)) {
             pendingFileCount++;
@@ -281,30 +290,93 @@ type ResolvedSpecifier = {
 
 /**
  * Resolve an import specifier. Uses HTML-spec semantics for URLs and relative
- * paths, and returns an unpkg.com URL for bare-specifiers.
+ * paths. Uses import map configuration if provided and matching, otherwise
+ * falls back to unpkg.com URL for bare-specifiers.
  */
-const resolveSpecifier = (
-  specifier: string,
-  referrer: string | URL
-): ResolvedSpecifier => {
-  try {
-    return {
-      type: 'url' as const,
-      url: new URL(specifier).href,
-    };
-  } catch (e) {
-    if (isRelativeOrAbsolutePath(specifier)) {
+class ModuleResolver {
+  private importMap: ModuleImportMap;
+
+  constructor(importMap: ModuleImportMap) {
+    this.importMap = importMap;
+  }
+
+  resolve(specifier: string, referrer: string | URL): ResolvedSpecifier {
+    const importMapUrl = this._resolveUsingImportMap(specifier);
+    if (importMapUrl !== null) {
+      return {type: 'bare' as const, url: importMapUrl};
+    }
+    try {
       return {
-        type: 'relative' as const,
-        url: new URL(specifier, referrer).href,
+        type: 'url' as const,
+        url: new URL(specifier).href,
+      };
+    } catch (e) {
+      if (isRelativeOrAbsolutePath(specifier)) {
+        return {
+          type: 'relative' as const,
+          url: new URL(specifier, referrer).href,
+        };
+      }
+      return {
+        type: 'bare' as const,
+        url: `https://unpkg.com/${specifier}`,
       };
     }
-    return {
-      type: 'bare' as const,
-      url: `https://unpkg.com/${specifier}`,
-    };
   }
-};
+
+  private _resolveUsingImportMap(specifier: string): string | null {
+    // For overview, see https://github.com/WICG/import-maps
+    // For algorithm, see https://wicg.github.io/import-maps/#resolving
+    // TODO(aomarks) Add support for `scopes`.
+    for (const [specifierKey, resolutionResult] of Object.entries(
+      this.importMap.imports ?? {}
+    )) {
+      // Note that per spec we shouldn't do a lookup for the exact match case,
+      // because if a trailing-slash mapping also matches and comes first, it
+      // should have precedence.
+      if (specifierKey === specifier) {
+        return resolutionResult;
+      }
+
+      if (specifierKey.endsWith('/') && specifier.startsWith(specifierKey)) {
+        if (!resolutionResult.endsWith('/')) {
+          console.warn(
+            `Could not resolve module specifier "${specifier}"` +
+              ` using import map key "${specifierKey}" because` +
+              ` address "${resolutionResult}" must end in a forward-slash.`
+          );
+          return null;
+        }
+
+        const afterPrefix = specifier.substring(specifierKey.length);
+        let url;
+        try {
+          url = new URL(afterPrefix, resolutionResult);
+        } catch {
+          console.warn(
+            `Could not resolve module specifier "${specifier}"` +
+              ` using import map key "${specifierKey}" because` +
+              ` "${afterPrefix}" could not be parsed` +
+              ` relative to "${resolutionResult}".`
+          );
+          return null;
+        }
+
+        const urlSerialized = url.href;
+        if (!urlSerialized.startsWith(resolutionResult)) {
+          console.warn(
+            `Could not resolve module specifier "${specifier}"` +
+              ` using import map key "${specifierKey}" because` +
+              ` "${afterPrefix}" backtracked above "${resolutionResult}".`
+          );
+          return null;
+        }
+        return urlSerialized;
+      }
+    }
+    return null;
+  }
+}
 
 class WorkerLanguageServiceHost implements ts.LanguageServiceHost {
   readonly compilerOptions: ts.CompilerOptions;


### PR DESCRIPTION
### Added

- Import maps are now supported. This allows customizing the URL that a bare
  module specifier resolves to, e.g. to a specific version, or to a different
  CDN.

  Note that import maps currently only apply to the _immediate imports of
  project source files_, not to external transitive dependencies.

  Also note `scopes` are not yet supported, only `imports`.

  See https://github.com/WICG/import-maps and
  https://wicg.github.io/import-maps/ for more information on import maps.

  Previously, all bare modules resolved to unpkg.com URLs at the latest version.
  This continues to be the fallback behavior if no import map is provided, or no
  entry in it matches.

  To specify an import map in a JSON project manifest, add an `importMap`
  property:

  ```json
  {
    "files": {
      "index.html": {},
      "my-element.ts": {}
    },
    "importMap": {
      "imports": {
        "lit-html": "https://unpkg.com/lit-html@next-major",
        "lit-html/": "https://unpkg.com/lit-html@next-major/"
      }
    }
  }
  ```

  To specify an import map inline, add a `<script type="sample/importmap">`
  slotted child:

  ```html
  <playground-ide>
    <script type="sample/importmap">
      {
        "imports": {
          "lit-html": "https://unpkg.com/lit-html@next-major",
          "lit-html/": "https://unpkg.com/lit-html@next-major/"
        }
      }
    </script>
    ...
  </playground-ide>
  ```

### Fixed

- Bare module imports in `.js` files are now resolved in the same way as `.ts`
  files.


Fixes https://github.com/PolymerLabs/playground-elements/issues/92 and https://github.com/PolymerLabs/playground-elements/issues/94