### PR TITLE
Latest-wins behavior for projectSrc vs files property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
+## Unreleased
+
+### Changed
+
+- [**BREAKING**] When both `projectSrc` and `files` are set, it is now the _most
+  recently set_ property that wins. Previously, `files` always won.
+
+- `<playground-preview>` now auto-reloads after 300ms, previously 500ms.
+
+### Added
+
+- `<playground-project>` now emits a `compileStart` and `compileDone` event.
+
+### Removed
+
+- [**BREAKING**] `<playground-project>` no longer emits a `contentChanged` event.
+
 ## [0.4.3] - 2021-01-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "playground-elements",
-  "version": "0.4.3",
+  "version": "0.5.0-pre.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.3",
+      "version": "0.5.0-pre.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@material/mwc-button": "^0.20.0",
@@ -16,7 +16,9 @@
         "@material/mwc-tab": "^0.20.0",
         "@material/mwc-tab-bar": "^0.20.0",
         "@material/mwc-textfield": "^0.20.0",
+        "@types/es-module-lexer": "^0.3.0",
         "comlink": "^4.3.0",
+        "es-module-lexer": "^0.3.26",
         "lit-element": "^2.3.1",
         "lit-html": "^1.2.1",
         "tslib": "^2.0.3"
@@ -1069,6 +1071,11 @@
         "@types/keygrip": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/es-module-lexer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/es-module-lexer/-/es-module-lexer-0.3.0.tgz",
+      "integrity": "sha512-XI3MGSejUQIJ3wzY0i5IHy5J3eb36M/ytgG8jIOssP08ovtRPcjpjXQqrx51AHBNBOisTS/NQNWJitI17+EwzQ=="
     },
     "node_modules/@types/estree": {
       "version": "0.0.39",
@@ -2795,8 +2802,7 @@
     "node_modules/es-module-lexer": {
       "version": "0.3.26",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.26.tgz",
-      "integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==",
-      "dev": true
+      "integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA=="
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
@@ -7686,6 +7692,11 @@
         "@types/node": "*"
       }
     },
+    "@types/es-module-lexer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/es-module-lexer/-/es-module-lexer-0.3.0.tgz",
+      "integrity": "sha512-XI3MGSejUQIJ3wzY0i5IHy5J3eb36M/ytgG8jIOssP08ovtRPcjpjXQqrx51AHBNBOisTS/NQNWJitI17+EwzQ=="
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -9087,8 +9098,7 @@
     "es-module-lexer": {
       "version": "0.3.26",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.26.tgz",
-      "integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==",
-      "dev": true
+      "integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA=="
     },
     "escape-html": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playground-elements",
-  "version": "0.4.3",
+  "version": "0.5.0-pre.1",
   "description": "A multi-file code editor component with live preview",
   "homepage": "https://github.com/PolymerLabs/playground-elements#readme",
   "repository": "github:PolymerLabs/playground-elements",
@@ -78,7 +78,9 @@
     "@material/mwc-tab": "^0.20.0",
     "@material/mwc-tab-bar": "^0.20.0",
     "@material/mwc-textfield": "^0.20.0",
+    "@types/es-module-lexer": "^0.3.0",
     "comlink": "^4.3.0",
+    "es-module-lexer": "^0.3.26",
     "lit-element": "^2.3.1",
     "lit-html": "^1.2.1",
     "tslib": "^2.0.3"

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -153,9 +153,60 @@ export class PlaygroundIde extends LitElement {
 
   /**
    * A document-relative path to a project configuration file.
+   *
+   * When both `projectSrc` and `files` are set, the one set most recently wins.
+   * Slotted children win only if both `projectSrc` and `files` are undefined.
    */
-  @property({attribute: 'project-src'})
-  projectSrc?: string;
+  @property({attribute: 'project-src', hasChanged: () => false})
+  get projectSrc(): string | undefined {
+    // To minimize synchronization complexity, we delegate the `projectSrc` and
+    // `files` getters/setters directly to our <playground-project>. The only
+    // case we need to handle is properties set before upgrade or before we
+    // first render the <playground-project>.
+    //
+    // TODO(aomarks) Maybe a "delegate" decorator for this pattern?
+    const project = this._project;
+    if (project) {
+      return project.projectSrc;
+    } else {
+      // We haven't rendered yet.
+      return this._projectSrcSetBeforeRender;
+    }
+  }
+
+  set projectSrc(src: string | undefined) {
+    const project = this._project;
+    if (project) {
+      project.projectSrc = src;
+    } else {
+      this._projectSrcSetBeforeRender = src;
+    }
+  }
+
+  /**
+   * Get or set the array of project files.
+   *
+   * When both `projectSrc` and `files` are set, the one set most recently wins.
+   * Slotted children win only if both `projectSrc` and `files` are undefined.
+   */
+  @property({attribute: false, hasChanged: () => false})
+  get files(): SampleFile[] | undefined {
+    const project = this._project;
+    if (project) {
+      return project.files;
+    } else {
+      return this._filesSetBeforeRender;
+    }
+  }
+
+  set files(files: SampleFile[] | undefined) {
+    const project = this._project;
+    if (project) {
+      project.files = files;
+    } else {
+      this._filesSetBeforeRender = files;
+    }
+  }
 
   /**
    * Base URL for script execution sandbox.
@@ -205,14 +256,8 @@ export class PlaygroundIde extends LitElement {
   @property({type: Boolean})
   resizable = false;
 
-  /**
-   * Get or set the array of project files.
-   *
-   * Files set through this property always take precedence over `projectSrc`
-   * and slotted children.
-   */
-  @property({attribute: false})
-  files?: SampleFile[];
+  @query('playground-project')
+  private _project!: PlaygroundProject;
 
   @query('#resizeBar')
   private _resizeBar!: HTMLDivElement;
@@ -220,8 +265,8 @@ export class PlaygroundIde extends LitElement {
   @query('#rhs')
   private _rhs!: HTMLDivElement;
 
-  @query('playground-project')
-  private _project!: PlaygroundProject;
+  private _filesSetBeforeRender?: SampleFile[];
+  private _projectSrcSetBeforeRender?: string;
 
   render() {
     const projectId = 'project';
@@ -229,9 +274,6 @@ export class PlaygroundIde extends LitElement {
     return html`
       <playground-project
         id=${projectId}
-        .files=${this.files}
-        @filesChanged=${this._onFilesChanged}
-        .projectSrc=${this.projectSrc}
         .sandboxBaseUrl=${this.sandboxBaseUrl}
         .sandboxScope=${this.sandboxScope}
       >
@@ -260,7 +302,7 @@ export class PlaygroundIde extends LitElement {
         ${this.resizable
           ? html`<div
               id="resizeBar"
-              @pointerdown=${this.onResizeBarPointerdown}
+              @pointerdown=${this._onResizeBarPointerdown}
             ></div>`
           : nothing}
 
@@ -276,6 +318,17 @@ export class PlaygroundIde extends LitElement {
     `;
   }
 
+  firstUpdated() {
+    if (this._filesSetBeforeRender) {
+      this._project.files = this._filesSetBeforeRender;
+      this._filesSetBeforeRender = undefined;
+    }
+    if (this._projectSrcSetBeforeRender) {
+      this._project.projectSrc = this._projectSrcSetBeforeRender;
+      this._projectSrcSetBeforeRender = undefined;
+    }
+  }
+
   async update(changedProperties: PropertyValues<this>) {
     if (changedProperties.has('resizable') && this.resizable === false) {
       // Note we set this property on the RHS element instead of the host so
@@ -286,11 +339,7 @@ export class PlaygroundIde extends LitElement {
     super.update(changedProperties);
   }
 
-  private _onFilesChanged() {
-    this.files = this._project.files;
-  }
-
-  private onResizeBarPointerdown({pointerId}: PointerEvent) {
+  private _onResizeBarPointerdown({pointerId}: PointerEvent) {
     const bar = this._resizeBar;
     bar.setPointerCapture(pointerId);
 

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -164,6 +164,11 @@ export class PlaygroundIde extends LitElement {
     // case we need to handle is properties set before upgrade or before we
     // first render the <playground-project>.
     //
+    // Note we set `hasChanged: () => false` because we don't need to trigger
+    // `update` when this property changes. (Why be a lit property at all?
+    // Because we want [1] to respond to atribute changes, and [2] to inherit
+    // property values set before upgrade).
+    //
     // TODO(aomarks) Maybe a "delegate" decorator for this pattern?
     const project = this._project;
     if (project) {

--- a/src/playground-preview.ts
+++ b/src/playground-preview.ts
@@ -135,13 +135,13 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
       const oldProject = changedProperties.get('_project') as PlaygroundProject;
       if (oldProject) {
         oldProject.removeEventListener('urlChanged', this.reload);
-        oldProject.removeEventListener('filesChanged', this.reload);
-        oldProject.removeEventListener('contentChanged', this.reload);
+        // To be more responsive, we start loading as soon as compilation
+        // starts. This is safe because requests block on compilation finishing.
+        oldProject.removeEventListener('compileStart', this.reload);
       }
       if (this._project) {
         this._project.addEventListener('urlChanged', this.reload);
-        this._project.addEventListener('filesChanged', this.reload);
-        this._project.addEventListener('contentChanged', this.reload);
+        this._project.addEventListener('compileStart', this.reload);
       }
     }
     super.update(changedProperties);


### PR DESCRIPTION
Previously, `files` always won over `projectSrc`. Now, the most recently set wins.

This came up for the lit playground, because we need to toggle between the two ways, as the user moves between static examples and base64 URLs.

Also:

- Refactor `<playground-ide>` so that its `files` getter/setter now directly delegates to `<playground-project>` instead of keeping its own copy, to eliminate out-of-sync errors, and a buggy property-setting loop.
- Emit `compileStart` and `compileDone` events, so that the preview can start indicating that a reload is happening even before compilation completes.
- Reduce the reload-after-typing time from 500ms to 300ms to feel more responsive.