### PR TITLE
Add a VSCode theme importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ preview. Mix-and-match components to create any layout you want, or just use
 #### 🎨 Themable
 
 Playground is fully themeable with CSS Custom Properties, down to the color of
-each kind of syntax-highlighted token. It comes with lots of preset themes, too.
+each kind of syntax-highlighted token. You can import themes from VSCode using
+the [configurator](https://polymerlabs.github.io/playground-elements/), and it
+comes with a number of presets too.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.1.5",
+        "@material/mwc-dialog": "^0.20.0",
         "@rollup/plugin-commonjs": "^17.0.0",
         "@rollup/plugin-node-resolve": "^11.0.0",
         "@rollup/plugin-replace": "^2.3.3",
@@ -181,10 +182,54 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@material/button": {
+      "version": "9.0.0-canary.1c156d69d.0",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-9.0.0-canary.1c156d69d.0.tgz",
+      "integrity": "sha512-ZjBDrGy2kKPmlIYaL99/C1D0t+MCIkP3Pcj9Y1RxxYdayvP+o8evkBUz5IRtg5NpW4o1X89x8RfF/JmLJZrdYw==",
+      "dev": true,
+      "dependencies": {
+        "@material/density": "9.0.0-canary.1c156d69d.0",
+        "@material/elevation": "9.0.0-canary.1c156d69d.0",
+        "@material/feature-targeting": "9.0.0-canary.1c156d69d.0",
+        "@material/ripple": "9.0.0-canary.1c156d69d.0",
+        "@material/rtl": "9.0.0-canary.1c156d69d.0",
+        "@material/shape": "9.0.0-canary.1c156d69d.0",
+        "@material/theme": "9.0.0-canary.1c156d69d.0",
+        "@material/touch-target": "9.0.0-canary.1c156d69d.0",
+        "@material/typography": "9.0.0-canary.1c156d69d.0"
+      }
+    },
     "node_modules/@material/density": {
       "version": "9.0.0-canary.1c156d69d.0",
       "resolved": "https://registry.npmjs.org/@material/density/-/density-9.0.0-canary.1c156d69d.0.tgz",
       "integrity": "sha512-Y87bUpTsXNDOi1q5NVRBxIyTUAFda1PP1Z9HOvgpV19n7/F6YLrttLGcOFSRFfx9btUKf4EddctBzwzBrF71TQ=="
+    },
+    "node_modules/@material/dialog": {
+      "version": "9.0.0-canary.1c156d69d.0",
+      "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-9.0.0-canary.1c156d69d.0.tgz",
+      "integrity": "sha512-JadtYwhCPrvZce/0j+kUuSq5+QaXAbZ1yx2FPT01K6/mzEgM0eDuU7ta7IlGGoJXFzmQI8jy7WsTSuW+IBNC8A==",
+      "dev": true,
+      "dependencies": {
+        "@material/animation": "9.0.0-canary.1c156d69d.0",
+        "@material/base": "9.0.0-canary.1c156d69d.0",
+        "@material/button": "9.0.0-canary.1c156d69d.0",
+        "@material/dom": "9.0.0-canary.1c156d69d.0",
+        "@material/elevation": "9.0.0-canary.1c156d69d.0",
+        "@material/feature-targeting": "9.0.0-canary.1c156d69d.0",
+        "@material/ripple": "9.0.0-canary.1c156d69d.0",
+        "@material/rtl": "9.0.0-canary.1c156d69d.0",
+        "@material/shape": "9.0.0-canary.1c156d69d.0",
+        "@material/theme": "9.0.0-canary.1c156d69d.0",
+        "@material/touch-target": "9.0.0-canary.1c156d69d.0",
+        "@material/typography": "9.0.0-canary.1c156d69d.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@material/dialog/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@material/dom": {
       "version": "9.0.0-canary.1c156d69d.0",
@@ -368,6 +413,23 @@
         "lit-element": "^2.3.0",
         "lit-html": "^1.1.2",
         "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/mwc-dialog": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-dialog/-/mwc-dialog-0.20.0.tgz",
+      "integrity": "sha512-7VG8M0p2xaqs+gFDQLNQiVSKJNe+j8jemYX94wxRMZaMRryX09uPrOkn1CGUAuAy0fivxVLhlFG6KINbGR/Avg==",
+      "dev": true,
+      "dependencies": {
+        "@material/dialog": "=9.0.0-canary.1c156d69d.0",
+        "@material/dom": "=9.0.0-canary.1c156d69d.0",
+        "@material/mwc-base": "^0.20.0",
+        "@material/mwc-button": "^0.20.0",
+        "blocking-elements": "^0.1.0",
+        "lit-element": "^2.3.0",
+        "lit-html": "^1.1.2",
+        "tslib": "^2.0.1",
+        "wicg-inert": "^3.0.0"
       }
     },
     "node_modules/@material/mwc-floating-label": {
@@ -2013,6 +2075,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/blocking-elements": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/blocking-elements/-/blocking-elements-0.1.1.tgz",
+      "integrity": "sha512-/SLWbEzMoVIMZACCyhD/4Ya2M1PWP1qMKuiymowPcI+PdWDARqeARBjhj73kbUBCxEmTZCUu5TAqxtwUO9C1Ig==",
+      "dev": true
+    },
     "node_modules/boxen": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.0.1.tgz",
@@ -3231,20 +3299,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -6187,11 +6241,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6851,6 +6900,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wicg-inert": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.1.tgz",
+      "integrity": "sha512-PhBaNh8ur9Xm4Ggy4umelwNIP6pPP1bv3EaWaKqfb/QNme2rdLjm7wIInvV4WhxVHhzA4Spgw9qNSqWtB/ca2A==",
+      "dev": true
+    },
     "node_modules/wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -7159,10 +7214,56 @@
         }
       }
     },
+    "@material/button": {
+      "version": "9.0.0-canary.1c156d69d.0",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-9.0.0-canary.1c156d69d.0.tgz",
+      "integrity": "sha512-ZjBDrGy2kKPmlIYaL99/C1D0t+MCIkP3Pcj9Y1RxxYdayvP+o8evkBUz5IRtg5NpW4o1X89x8RfF/JmLJZrdYw==",
+      "dev": true,
+      "requires": {
+        "@material/density": "9.0.0-canary.1c156d69d.0",
+        "@material/elevation": "9.0.0-canary.1c156d69d.0",
+        "@material/feature-targeting": "9.0.0-canary.1c156d69d.0",
+        "@material/ripple": "9.0.0-canary.1c156d69d.0",
+        "@material/rtl": "9.0.0-canary.1c156d69d.0",
+        "@material/shape": "9.0.0-canary.1c156d69d.0",
+        "@material/theme": "9.0.0-canary.1c156d69d.0",
+        "@material/touch-target": "9.0.0-canary.1c156d69d.0",
+        "@material/typography": "9.0.0-canary.1c156d69d.0"
+      }
+    },
     "@material/density": {
       "version": "9.0.0-canary.1c156d69d.0",
       "resolved": "https://registry.npmjs.org/@material/density/-/density-9.0.0-canary.1c156d69d.0.tgz",
       "integrity": "sha512-Y87bUpTsXNDOi1q5NVRBxIyTUAFda1PP1Z9HOvgpV19n7/F6YLrttLGcOFSRFfx9btUKf4EddctBzwzBrF71TQ=="
+    },
+    "@material/dialog": {
+      "version": "9.0.0-canary.1c156d69d.0",
+      "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-9.0.0-canary.1c156d69d.0.tgz",
+      "integrity": "sha512-JadtYwhCPrvZce/0j+kUuSq5+QaXAbZ1yx2FPT01K6/mzEgM0eDuU7ta7IlGGoJXFzmQI8jy7WsTSuW+IBNC8A==",
+      "dev": true,
+      "requires": {
+        "@material/animation": "9.0.0-canary.1c156d69d.0",
+        "@material/base": "9.0.0-canary.1c156d69d.0",
+        "@material/button": "9.0.0-canary.1c156d69d.0",
+        "@material/dom": "9.0.0-canary.1c156d69d.0",
+        "@material/elevation": "9.0.0-canary.1c156d69d.0",
+        "@material/feature-targeting": "9.0.0-canary.1c156d69d.0",
+        "@material/ripple": "9.0.0-canary.1c156d69d.0",
+        "@material/rtl": "9.0.0-canary.1c156d69d.0",
+        "@material/shape": "9.0.0-canary.1c156d69d.0",
+        "@material/theme": "9.0.0-canary.1c156d69d.0",
+        "@material/touch-target": "9.0.0-canary.1c156d69d.0",
+        "@material/typography": "9.0.0-canary.1c156d69d.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
     },
     "@material/dom": {
       "version": "9.0.0-canary.1c156d69d.0",
@@ -7360,6 +7461,23 @@
         "lit-element": "^2.3.0",
         "lit-html": "^1.1.2",
         "tslib": "^2.0.1"
+      }
+    },
+    "@material/mwc-dialog": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-dialog/-/mwc-dialog-0.20.0.tgz",
+      "integrity": "sha512-7VG8M0p2xaqs+gFDQLNQiVSKJNe+j8jemYX94wxRMZaMRryX09uPrOkn1CGUAuAy0fivxVLhlFG6KINbGR/Avg==",
+      "dev": true,
+      "requires": {
+        "@material/dialog": "=9.0.0-canary.1c156d69d.0",
+        "@material/dom": "=9.0.0-canary.1c156d69d.0",
+        "@material/mwc-base": "^0.20.0",
+        "@material/mwc-button": "^0.20.0",
+        "blocking-elements": "^0.1.0",
+        "lit-element": "^2.3.0",
+        "lit-html": "^1.1.2",
+        "tslib": "^2.0.1",
+        "wicg-inert": "^3.0.0"
       }
     },
     "@material/mwc-floating-label": {
@@ -8833,6 +8951,12 @@
         }
       }
     },
+    "blocking-elements": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/blocking-elements/-/blocking-elements-0.1.1.tgz",
+      "integrity": "sha512-/SLWbEzMoVIMZACCyhD/4Ya2M1PWP1qMKuiymowPcI+PdWDARqeARBjhj73kbUBCxEmTZCUu5TAqxtwUO9C1Ig==",
+      "dev": true
+    },
     "boxen": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.0.1.tgz",
@@ -9794,13 +9918,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -12641,6 +12758,12 @@
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "wicg-inert": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.1.tgz",
+      "integrity": "sha512-PhBaNh8ur9Xm4Ggy4umelwNIP6pPP1bv3EaWaKqfb/QNme2rdLjm7wIInvV4WhxVHhzA4Spgw9qNSqWtB/ca2A==",
+      "dev": true
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   ],
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
+    "@material/mwc-dialog": "^0.20.0",
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
     "@rollup/plugin-replace": "^2.3.3",

--- a/src/configurator/highlight-tokens.ts
+++ b/src/configurator/highlight-tokens.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+export const tokens = [
+  {
+    id: 'codeBackground',
+    label: 'Background',
+    cssProperty: '--playground-code-background',
+    defaultValue: '#ffffff',
+  },
+  {
+    id: 'synDefault',
+    label: 'Default',
+    cssProperty: '--playground-code-default-color',
+    cmClass: '.CodeMirror-line [role="presentation"]',
+    defaultValue: '#000000',
+  },
+  {
+    id: 'synKeyword',
+    label: 'Keyword',
+    cssProperty: '--playground-code-keyword-color',
+    cmClass: 'cm-keyword',
+    defaultValue: '#770088',
+  },
+  {
+    id: 'synAtom',
+    label: 'Atom',
+    cssProperty: '--playground-code-atom-color',
+    cmClass: 'cm-atom',
+    defaultValue: '#221199',
+  },
+  {
+    id: 'synNumber',
+    label: 'Number',
+    cssProperty: '--playground-code-number-color',
+    cmClass: 'cm-number',
+    defaultValue: '#116644',
+  },
+  {
+    id: 'synDef',
+    label: 'Def',
+    cssProperty: '--playground-code-def-color',
+    cmClass: 'cm-def',
+    defaultValue: '#0000ff',
+  },
+  {
+    id: 'synVariable',
+    label: 'Variable',
+    cssProperty: '--playground-code-variable-color',
+    cmClass: 'cm-variable',
+    defaultValue: '#000000',
+  },
+  {
+    id: 'synProperty',
+    label: 'Property',
+    cssProperty: '--playground-code-property-color',
+    cmClass: 'cm-property',
+    defaultValue: '#000000',
+  },
+  {
+    id: 'synOperator',
+    label: 'Operator',
+    cssProperty: '--playground-code-operator-color',
+    cmClass: 'cm-operator',
+    defaultValue: '#000000',
+  },
+  {
+    id: 'synVariable2',
+    label: 'Variable 2',
+    cssProperty: '--playground-code-variable-2-color',
+    cmClass: 'cm-variable-2',
+    defaultValue: '#0055aa',
+  },
+  {
+    id: 'synVariable3',
+    label: 'Variable 3',
+    cssProperty: '--playground-code-variable-3-color',
+    cmClass: 'cm-variable-3',
+    defaultValue: '#008855',
+  },
+  {
+    id: 'synType',
+    label: 'Type',
+    cssProperty: '--playground-code-type-color',
+    cmClass: 'cm-type',
+    defaultValue: '#008855',
+  },
+  {
+    id: 'synComment',
+    label: 'Comment',
+    cssProperty: '--playground-code-comment-color',
+    cmClass: 'cm-comment',
+    defaultValue: '#aa5500',
+  },
+  {
+    id: 'synString',
+    label: 'String',
+    cssProperty: '--playground-code-string-color',
+    cmClass: 'cm-string',
+    defaultValue: '#aa1111',
+  },
+  {
+    id: 'synString2',
+    label: 'String 2',
+    cssProperty: '--playground-code-string-2-color',
+    cmClass: 'cm-string-2',
+    defaultValue: '#ff5500',
+  },
+  {
+    id: 'synMeta',
+    label: 'Meta',
+    cssProperty: '--playground-code-meta-color',
+    cmClass: 'cm-meta',
+    defaultValue: '#555555',
+  },
+  {
+    id: 'synQualifier',
+    label: 'Qualifier',
+    cssProperty: '--playground-code-qualifier-color',
+    cmClass: 'cm-qualifier',
+    defaultValue: '#555555',
+  },
+  {
+    id: 'synBuiltin',
+    label: 'Builtin',
+    cssProperty: '--playground-code-builtin-color',
+    cmClass: 'cm-builtin',
+    defaultValue: '#3300aa',
+  },
+  {
+    id: 'synTag',
+    label: 'Tag',
+    cssProperty: '--playground-code-tag-color',
+    cmClass: 'cm-tag',
+    defaultValue: '#117700',
+  },
+  {
+    id: 'synAttribute',
+    label: 'Attribute',
+    cssProperty: '--playground-code-attribute-color',
+    cmClass: 'cm-attribute',
+    defaultValue: '#0000cc',
+  },
+  {
+    id: 'synCallee',
+    label: 'Callee',
+    cssProperty: '--playground-code-callee-color',
+    cmClass: 'cm-callee',
+    defaultValue: '#000000',
+  },
+  // TODO(aomarks) local?
+] as const;

--- a/src/configurator/playground-theme-detector.ts
+++ b/src/configurator/playground-theme-detector.ts
@@ -1,0 +1,380 @@
+/**
+ * @license
+ * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {
+  LitElement,
+  customElement,
+  html,
+  css,
+  internalProperty,
+  query,
+} from 'lit-element';
+import '../playground-code-editor.js';
+import {PlaygroundCodeEditor} from '../playground-code-editor.js';
+import '@material/mwc-tab-bar';
+import {tokens} from './highlight-tokens.js';
+
+@customElement('playground-theme-detector')
+export class PlaygroundThemeDetector extends LitElement {
+  static styles = css`
+    ol {
+      padding-left: 24px;
+    }
+
+    li {
+      margin-bottom: 1em;
+    }
+
+    button,
+    label {
+      cursor: pointer;
+    }
+
+    #pasteArea {
+      cursor: pointer;
+    }
+
+    iframe {
+      width: 100%;
+      pointer-events: none;
+      margin-bottom: 1em;
+    }
+
+    playground-code-editor {
+      position: absolute;
+      visibility: hidden;
+      width: 1px;
+      height: 1px;
+    }
+
+    #palette {
+      display: flex;
+      margin-bottom: 2em;
+    }
+
+    .color {
+      height: 25px;
+      flex: 1;
+    }
+
+    #buttons {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    #buttons > button {
+      margin-left: 1em;
+      font-size: 18px;
+    }
+  `;
+
+  @internalProperty()
+  private _filetype: 'ts' | 'html' | 'css' = 'ts';
+
+  @internalProperty()
+  private _iframeSrcdoc: string = '';
+
+  @internalProperty()
+  private _codeText: string = '';
+
+  @internalProperty()
+  private _propertyValues = new Map<string, string | null>([
+    ['--playground-code-background', null],
+    ...tokens.map(({cssProperty}) => [cssProperty, null]),
+  ] as any);
+
+  @query('iframe')
+  private _iframeWithUserHtml!: HTMLIFrameElement;
+
+  @query('playground-code-editor')
+  private _playgroundWithUserText!: PlaygroundCodeEditor;
+
+  render() {
+    return html`
+      <h2>Theme detector</h2>
+
+      <ol>
+        <li>
+          Pick a theme in VSCode<br />
+          or any editor that copies as styled HTML
+        </li>
+
+        <li>
+          Open a file with a variety of syntax<br />
+          or click to copy a sample to paste:
+          <br />
+          <button @click=${() => this._copySample('ts')}>TypeScript</button>
+          <button @click=${() => this._copySample('html')}>HTML</button>
+          <button @click=${() => this._copySample('css')}>CSS</button>
+        </li>
+
+        <li>Select All and Copy</li>
+
+        <li>
+          Confirm the filetype:
+          <br />
+          <label
+            ><input
+              type="radio"
+              name="type"
+              value="ts"
+              .checked=${this._filetype === 'ts'}
+            />TypeScript</label
+          >
+          <label
+            ><input
+              type="radio"
+              name="type"
+              value="html"
+              .checked=${this._filetype === 'html'}
+            />HTML</label
+          >
+          <label
+            ><input
+              type="radio"
+              name="type"
+              value="css"
+              .checked=${this._filetype === 'css'}
+            />CSS</label
+          >
+        </li>
+        <li>Click in the box below to paste and extract:</li>
+      </ol>
+
+      <div id="pasteArea" @click=${this._onClickPasteButton}>
+        <iframe
+          sandbox="allow-same-origin"
+          srcdoc=${this._iframeSrcdoc}
+          @load=${this._extractStyles}
+        ></iframe>
+      </div>
+
+      <playground-code-editor
+        .type=${this._filetype}
+        .value=${this._codeText}
+      ></playground-code-editor>
+
+      <div id="palette">
+        ${[...this._propertyValues].map(
+          ([prop, color]) =>
+            html`<span
+              class="color"
+              title=${prop}
+              style="background:${color ?? 'transparent'}"
+            ></span>`
+        )}
+      </div>
+
+      <div id="buttons">
+        <button
+          @click=${this._onClickApply}
+          .disabled=${![...this._propertyValues.values()].some(
+            (val) => val !== null
+          )}
+        >
+          Apply
+        </button>
+        <button @click=${this._onClickCancel}>Cancel</button>
+      </div>
+    `;
+  }
+
+  async firstUpdated() {
+    // CodeMirror only renders visible lines plus some margin. Force it to
+    // render everything so we can query it.
+    await this._playgroundWithUserText.updateComplete;
+    (this._playgroundWithUserText as any)._codemirror.setOption(
+      'viewportMargin',
+      Infinity
+    );
+  }
+
+  async _copySample(filetype: 'ts' | 'html' | 'css') {
+    this._filetype = filetype;
+    await navigator.clipboard.writeText(sampleFiles[this._filetype]);
+  }
+
+  async _onClickPasteButton() {
+    const {html, text} = await this._readClipboard();
+    if (!html || !text) {
+      return;
+    }
+    // Load the HTML format of the paste into a sandboxed iframe.
+    this._iframeSrcdoc = `<style>body{margin:0}</style>` + html;
+    // Load the text format of the paste into our own highlighter.
+    this._codeText = text;
+  }
+
+  private async _readClipboard(): Promise<{html: string; text: string}> {
+    let html = '';
+    let text = '';
+    const items = await (navigator.clipboard as any).read();
+    for (const item of items) {
+      for (const type of item.types) {
+        if (type === 'text/html') {
+          const blob = await item.getType(type);
+          html = await blob.text();
+        } else if (type === 'text/plain') {
+          const blob = await item.getType(type);
+          text = await blob.text();
+        }
+      }
+    }
+    return {html, text};
+  }
+
+  private _extractStyles() {
+    if (!this._iframeSrcdoc) {
+      // We get an iframe load event even if there is no srcdoc.
+      return;
+    }
+
+    // Create a map from example text fragments to the CSS property for that
+    // token, extracted from *our* version of the highlighted text. E.g.:
+    //
+    //   import => --playground-code-keyword-color
+    //   "foo"  => --playground-code-string-color
+    //   42     => --playground-code-number-color
+    const fragmentToProperty = new Map<string, string[]>();
+    const ourWalker = document.createTreeWalker(
+      this._playgroundWithUserText.shadowRoot!,
+      NodeFilter.SHOW_TEXT
+    );
+    while (ourWalker.nextNode()) {
+      const textNode = ourWalker.currentNode;
+      const parent = textNode.parentElement;
+      if (parent === null) {
+        continue;
+      }
+
+      let property;
+      const cmClasses = [...parent.classList].filter((c) =>
+        c.startsWith('cm-')
+      );
+      if (cmClasses.length > 0) {
+        // The last CodeMirror class tends to be more specific (e.g. `callee` is
+        // more specific than `variable`).
+        const lastClass = cmClasses[cmClasses.length - 1];
+        const cmToken = lastClass.slice('cm-'.length);
+        property = `--playground-code-${cmToken}-color`;
+      } else if (parent.getAttribute('role') === 'presentation') {
+        // Code with no special token classes.
+        property = `--playground-code-default-color`;
+      } else {
+        continue;
+      }
+      // Some highlighters put HTML angle brackets in their own <span>, but our
+      // CodeMirror highlighter doesn't. Trim off the brackets so we're more
+      // likely to match.
+      const text = textNode.textContent!.replace(/^<\/?/, '').replace(/>$/, '');
+      // The same token can appear multiple times but with different meaning. We
+      // can assume they'll appear in the same order in the iframe HTML as they
+      // do here, which is captured by the order of items in this array.
+      let arr = fragmentToProperty.get(text);
+      if (!arr) {
+        arr = [];
+        fragmentToProperty.set(text, arr);
+      }
+      arr.push(property);
+    }
+
+    // Now walk over the HTML pasted by the user. Look for the example fragments
+    // we found above and query for their color.
+    const doc = this._iframeWithUserHtml.contentDocument!;
+    const theirWalker = doc.createTreeWalker(
+      doc.body,
+      NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT
+    );
+    let foundBackground = false;
+    while (theirWalker.nextNode()) {
+      const node = theirWalker.currentNode;
+
+      if (node.nodeType === Node.TEXT_NODE) {
+        const text = node.textContent!.replace(/^<\/?/, '').replace(/>$/, '');
+        const property = fragmentToProperty.get(text)?.shift();
+        if (property && this._propertyValues.get(property) === null) {
+          const color = window.getComputedStyle(node.parentElement!).color;
+          this._propertyValues.set(property, color);
+        }
+      } else if (!foundBackground && node.nodeType === Node.ELEMENT_NODE) {
+        // Use the first non-transparent background (depth first).
+        const background = window.getComputedStyle(node as Element)
+          .backgroundColor;
+        if (background !== 'rgba(0, 0, 0, 0)') {
+          foundBackground = true;
+          this._propertyValues.set('--playground-code-background', background);
+        }
+      }
+    }
+
+    // We updated the properties map in-place.
+    this.requestUpdate();
+  }
+
+  _onClickApply() {
+    this.dispatchEvent(
+      new CustomEvent<{properties: Map<string, string | null>}>('apply', {
+        detail: {
+          properties: this._propertyValues,
+        },
+      })
+    );
+  }
+
+  _onClickCancel() {
+    this.dispatchEvent(new CustomEvent('cancel'));
+  }
+}
+
+const sampleFiles = {
+  ts: `
+// Playground Sample TypeScript file
+/* Another kind of comment */
+let variable = 1 + 1 === 2 === true;
+const fn = (param: number) => param;
+fn(3);
+'string1';
+\`string2\`;
+\`string3 \${variable}\`
+export class Class {
+  property: string;
+}
+html\`
+  <!-- HTML comment -->
+  <!DOCTYPE html>
+  <button attr="val">text</button>
+\`;
+css\`
+  /* CSS comment */
+  p, #id, .class, a, :hover {
+    color: red;
+    content: 'c';
+  }
+\`;
+`.trim(),
+
+  html: `
+<!-- Playground sample HTML file -->
+<!DOCTYPE html>
+<button attr="val">text</button>
+`.trim(),
+
+  css: `
+/* Playground sample CSS file */
+p, #id, .class, a, :hover {
+  color: red;
+  content: 'c';
+}
+`.trim(),
+} as const;


### PR DESCRIPTION
Adds a widget to the configurator that allows you to import a theme from VSCode, or any other editor that copies to styled HTML.

Try it here: https://polymerlabs.github.io/playground-elements/

*Actually* understanding VSCode theme definitions would be pretty intractable, since it has a much more elaborate set of per-language tokens, plus theme extensions can run arbitrary JavaScript. Instead, this is a big hack that finds a good enough equivalence:

1. Take some file in VSCode, select all, copy, and paste into our widget.
2. Use the `text/plain` portion to create a Playground.
3. Dump the `text/html` portion into a sandboxed iframe.
4. Walk our Playground's CodeMirror DOM. Build a map from a text fragment (e.g. `import`) to the kind of token it is according to CodeMirror (e.g. `keyword`).
5. Walk the DOM of the pasted VSCode HTML in the iframe. For each text fragment, check the map to see which CodeMirror token it should correspond to, and grab the color from computed styles to find our theme color.

### Import widget

<img src="https://user-images.githubusercontent.com/48894/108817532-e000d200-756c-11eb-90f6-6784954c89a9.png" width="300">

### Result

<img src="https://user-images.githubusercontent.com/48894/108817472-cbbcd500-756c-11eb-9a2c-4545ef35c03c.png" width="500">

### New syntax highlight knobs

<img src="https://user-images.githubusercontent.com/48894/108817621-09216280-756d-11eb-96b1-1c387ad52a2c.png" width="200">
