### PR TITLE
Fix fold/hide infinite loop bug. Add content/contentType properties. Shorter license headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
+## Unreleased
+
+### Changed
+
+- License headers shortened to concise SPDX style.
+
 ## [0.6.1] - 2021-03-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - License headers shortened to concise SPDX style.
 
+### Fixed
+
+- Fixed infinite loop that could occur when switching between two files that
+  both contain code folding/hiding regions.
+
 ## [0.6.1] - 2021-03-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Added `content` and `contentType` as optional properties of the JSON manifest.
+
 ### Changed
 
 - License headers shortened to concise SPDX style.

--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,20 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, The Polymer Authors. All rights reserved.
+Copyright (c) 2019 Google LLC. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/README.md
+++ b/README.md
@@ -202,7 +202,19 @@ the `preserve-whitespace` attribute is present.
 
 ### Option 2: JSON manifest
 
-Serve a JSON file containing a `files` object, with relative filenames.
+Serve a JSON file containing a `files` object. Keys are filenames relative to
+the manifest URL. Values are objects with any of the following optional
+properties:
+
+- `content`: Optional text content of the file. If omitted, a `fetch` is made to
+  retrieve the file by filename, relative to the manifest URL.
+
+- `contentType`: Optional MIME type of the file. If omitted, type is taken from
+  either the `fetch` response `Content-Type` header, or inferred from the
+  filename extension when `content` is set.
+
+- `label`: Optional label for display in `playground-tab-bar`. If omitted, the
+  filename is displayed.
 
 ```html
 <playground-ide project-src="/path/to/my/project.json"> </playground-ide>
@@ -212,9 +224,15 @@ Serve a JSON file containing a `files` object, with relative filenames.
 {
   "files": {
     "index.html": {},
-    "javascript.js": {},
-    "typescript.ts": {},
-    "styles.css": {}
+    "typescript.ts": {
+      "content": "console.log('hello');"
+    },
+    "javascript.js": {
+      "contentType": "text/javascript"
+    },
+    "styles.css": {
+      "label": "Style"
+    }
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "format": "prettier src/**/*.ts --write",
     "prepublishOnly": "npm run build"
   },
-  "author": "The Polymer Authors",
+  "author": "Google LLC",
   "license": "BSD-3-Clause",
   "files": [
     "_codemirror/",

--- a/scripts/theme-generator.html
+++ b/scripts/theme-generator.html
@@ -1,12 +1,8 @@
 <!doctype html>
 
 <!--
-Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright 2020 Google LLC
+SPDX-License-Identifier: BSD-3-Clause
 -->
 
 <link rel="stylesheet" href="/node_modules/codemirror/lib/codemirror.css">

--- a/scripts/theme-generator.js
+++ b/scripts/theme-generator.js
@@ -1,11 +1,7 @@
 /**
  * @license
- * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 // This script generates the following files:

--- a/src/configurator/knobs.ts
+++ b/src/configurator/knobs.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /**

--- a/src/configurator/playground-configurator.ts
+++ b/src/configurator/playground-configurator.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {LitElement, customElement, html, css} from 'lit-element';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 export * from './playground-ide.js';

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -275,7 +275,7 @@ export class PlaygroundCodeEditor extends LitElement {
    * Create hidden and folded regions for playground-hide and playground-fold
    * comments.
    */
-  private _applyHideAndFoldRegions() {
+  private async _applyHideAndFoldRegions() {
     const cm = this._codemirror;
     if (!cm) {
       return;
@@ -284,7 +284,13 @@ export class PlaygroundCodeEditor extends LitElement {
     const value = cm.getValue();
     if (this._hideOrFoldRegionsActive) {
       // We need to reset any existing hide/fold regions. Hacky, but prodding
-      // the value this way works.
+      // the value this way works. We need to defer to a microtask though,
+      // because if we're already inside a CodeMirror change event callback
+      // stack, then these setValue calls will queue up two async change events
+      // that would fire later, and throw us for a loop. This way, the change
+      // events fire synchronously, and we can use our loop guard property
+      // correctly.
+      await null;
       this._ignoreValueChange = true;
       cm.setValue('');
       cm.setValue(value);

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {LitElement, customElement, css, property} from 'lit-element';

--- a/src/playground-connected-element.ts
+++ b/src/playground-connected-element.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {LitElement, property, internalProperty} from 'lit-element';

--- a/src/playground-file-editor.ts
+++ b/src/playground-file-editor.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {

--- a/src/playground-file-system-controls.ts
+++ b/src/playground-file-system-controls.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {

--- a/src/playground-preview.ts
+++ b/src/playground-preview.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -523,24 +523,31 @@ const fetchProject = async (url: string) => {
   const manifestFetched = await fetch(url);
   const manifest = (await manifestFetched.json()) as ProjectManifest;
 
-  const filenames = manifest.files ? Object.keys(manifest.files) : [];
   const files = await Promise.all(
-    filenames.map(async (filename) => {
-      const fileUrl = new URL(filename, projectUrl);
-      const response = await fetch(fileUrl.href);
-      if (response.status === 404) {
-        throw new Error(`Could not find file ${filename}`);
+    Object.entries(manifest.files ?? {}).map(
+      async ([name, {content, contentType, label}]) => {
+        if (content === undefined) {
+          const fileUrl = new URL(name, projectUrl);
+          const response = await fetch(fileUrl.href);
+          if (response.status === 404) {
+            throw new Error(`Could not find file ${name}`);
+          }
+          content = await response.text();
+          if (!contentType) {
+            contentType = response.headers.get('Content-Type') ?? undefined;
+          }
+        }
+        if (!contentType) {
+          contentType = typeFromFilename(name) ?? 'text/plain';
+        }
+        return {
+          name,
+          label,
+          content,
+          contentType,
+        };
       }
-
-      // Remember the mime type so that the service worker can set it
-      const contentType = response.headers.get('Content-Type') || undefined;
-      return {
-        name: filename,
-        label: manifest.files![filename].label,
-        content: await response.text(),
-        contentType,
-      };
-    })
+    )
   );
   return {files, importMap: manifest.importMap ?? {}};
 };
@@ -555,7 +562,6 @@ const typeFromFilename = (filename: string) => {
 };
 
 const typeEnumToMimeType = (type?: string) => {
-  // TODO: infer type based on extension too
   if (type === undefined) {
     return;
   }

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {

--- a/src/playground-service-worker-proxy.ts
+++ b/src/playground-service-worker-proxy.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {

--- a/src/playground-tab-bar.ts
+++ b/src/playground-tab-bar.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {

--- a/src/service-worker/playground-service-worker.ts
+++ b/src/service-worker/playground-service-worker.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {

--- a/src/shared/deferred.ts
+++ b/src/shared/deferred.ts
@@ -1,12 +1,7 @@
 /**
  * @license
- * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
- * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
- * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
- * Google as part of the polymer project is also subject to an additional IP
- * rights grant found at http://polymer.github.io/PATENTS.txt
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 export class Deferred<T> {

--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 export const endWithSlash = (s: string) => (s.endsWith('/') ? s : s + '/');

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 /**

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -83,9 +83,13 @@ export interface SampleFile {
 }
 
 export interface FileOptions {
-  // This is reserved to indicate if a file is a template, ie it shouldn't be
-  // loaded itself, but copied to create new files. It's currently unused.
-  isTemplate?: boolean;
+  /** Optional file content. If omitted, files are fetched by name. */
+  content?: string;
+  /**
+   * Optional content MIME type. If omitted, type is taken from fetch
+   * Content-Type header if available, otherwise inferred from filename.
+   */
+  contentType?: string;
   /** Optional display label. */
   label?: string;
 }

--- a/src/test/playground-code-editor_test.ts
+++ b/src/test/playground-code-editor_test.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {assert} from '@esm-bundle/chai';

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {assert} from '@esm-bundle/chai';

--- a/src/typescript-worker/playground-typescript-worker.ts
+++ b/src/typescript-worker/playground-typescript-worker.ts
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,15 +1,7 @@
 /**
  * @license
- * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 import {playwrightLauncher} from '@web/test-runner-playwright';


### PR DESCRIPTION
- Fix infinite loop bug that happened when switching between two files that both had fold/hide regions.
 
- Add content and contentType optional properties to JSON manifest. This can be used to more efficiently serve a playground project, with one request instead of N.

- Use short SPDX style headers.
