### PR TITLE
Add extends field to JSON configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added support for JSON files with syntax highlighting.
 
+- Added `extends` property to JSON config file, an optional URL of another JSON
+  config file to extend from. Useful for setting side-wide defaults.
+
 ### Fixed
 
 - Fixed bug where editor did not immediately switch to newly created files.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Set the `project-src` attribute or `projectSrc` property to a JSON file with for
 | `files.contentType` | Optional MIME type of the file. If omitted, type is taken from either the `fetch` response `Content-Type` header, or inferred from the filename extension when `content` is set. |
 | `files.label`       | Optional label for display in `playground-tab-bar`. If omitted, the filename is displayed.                                                                                       |
 | `files.hidden`      | If `true`, the file won't be visible in `playground-tab-bar`.                                                                                                                    |
-| `extends`           | Optional URL to another JSON config file to extend from. Configurations are deeply merged.                                                                                       |
+| `extends`           | Optional URL to another JSON config file to extend from. Configs are deeply merged. URLs are interpreted relative to the URL of each extendee config.                            |
 
 ```html
 <playground-ide project-src="/path/to/my/project.json"> </playground-ide>

--- a/README.md
+++ b/README.md
@@ -163,22 +163,16 @@ There are 3 ways to specify the files of a playground project:
 
 ### Option 1: Inline scripts
 
-Add one or more `<script type="sample/..." filename="...">` tags as children of
-your `<playground-ide>` or `<playground-project>`. The following attributes are
-available:
+Add one or more `<script>` tags as children of
+your `<playground-ide>` or `<playground-project>`, using the following attributes:
 
-- `type`: Required filetype. Valid options: `sample/html`, `sample/css`,
-  `sample/js`, `sample/ts`, `sample/json`, `sample/importmap`.
-
-- `filename`: Required filename.
-
-- `label`: Optional label for display in `playground-tab-bar`. If omitted, the
-  filename is displayed.
-
-- `hidden`: If present, the file won't be visible in `playground-tab-bar`.
-
-- `preserve-whitespace`: Disable the default behavior where leading whitespace
-  that is common to all lines is removed.
+| Attribute             |  Description                                                                                                          |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `type`                | Required filetype. Options: `sample/html`, `sample/css`, `sample/js`, `sample/ts`, `sample/json`, `sample/importmap`. |
+| `filename`            | Required filename.                                                                                                    |
+| `label`               | Optional label for display in `playground-tab-bar`. If omitted, the filename is displayed.                            |
+| `hidden`              | If present, the file won't be visible in `playground-tab-bar`.                                                        |
+| `preserve-whitespace` | Disable the default behavior where leading whitespace that is common to all lines is removed.                         |
 
 Be sure to escape closing `</script>` tags within your source as `<&lt;script>`.
 
@@ -210,23 +204,17 @@ Be sure to escape closing `</script>` tags within your source as `<&lt;script>`.
 </playground-project>
 ```
 
-### Option 2: JSON manifest
+### Option 2: JSON configuration
 
-Serve a JSON file containing a `files` object. Keys are filenames relative to
-the manifest URL. Values are objects with any of the following optional
-properties:
+Set the `project-src` attribute or `projectSrc` property to a JSON file with format:
 
-- `content`: Optional text content of the file. If omitted, a `fetch` is made to
-  retrieve the file by filename, relative to the manifest URL.
-
-- `contentType`: Optional MIME type of the file. If omitted, type is taken from
-  either the `fetch` response `Content-Type` header, or inferred from the
-  filename extension when `content` is set.
-
-- `label`: Optional label for display in `playground-tab-bar`. If omitted, the
-  filename is displayed.
-
-- `hidden`: If `true`, the file won't be visible in `playground-tab-bar`.
+| Property            |  Description                                                                                                                                                                     |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `files`             | An object mapping filenames to file data.                                                                                                                                        |
+| `files.content`     | Optional text content of the file. If omitted, a `fetch` is made to retrieve the file by filename, relative to the manifest URL.                                                 |
+| `files.contentType` | Optional MIME type of the file. If omitted, type is taken from either the `fetch` response `Content-Type` header, or inferred from the filename extension when `content` is set. |
+| `files.label`       | Optional label for display in `playground-tab-bar`. If omitted, the filename is displayed.                                                                                       |
+| `files.hidden`      | If `true`, the file won't be visible in `playground-tab-bar`.                                                                                                                    |
 
 ```html
 <playground-ide project-src="/path/to/my/project.json"> </playground-ide>

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Set the `project-src` attribute or `projectSrc` property to a JSON file with for
 | `files.contentType` | Optional MIME type of the file. If omitted, type is taken from either the `fetch` response `Content-Type` header, or inferred from the filename extension when `content` is set. |
 | `files.label`       | Optional label for display in `playground-tab-bar`. If omitted, the filename is displayed.                                                                                       |
 | `files.hidden`      | If `true`, the file won't be visible in `playground-tab-bar`.                                                                                                                    |
+| `extends`           | Optional URL to another JSON config file to extend from. Configurations are deeply merged.                                                                                       |
 
 ```html
 <playground-ide project-src="/path/to/my/project.json"> </playground-ide>

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -99,6 +99,8 @@ export interface FileOptions {
 }
 
 export interface ProjectManifest {
+  /** Optional project manifest URL to extend from */
+  extends?: string;
   files?: {[filename: string]: FileOptions};
   importMap?: ModuleImportMap;
 }


### PR DESCRIPTION
You can now set the `extends` property of a JSON config to another config file URL, and they'll be fetched and merged recursively. Useful for when we have a base config for a site that we want to inherit across a bunch of playgrounds.