### PR TITLE
Show basic TypeScript errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
+## Unreleased
+
+### Added
+
+- TypeScript errors are now displayed in the editor with red underlines. A
+  tooltip displaying the error is shown on hover.
+
+  - Note that only basic/syntactic errors are currently shown, because typings
+    of dependencies are not currently available to compilation.
+
+- Added CSS property `--playground-error-border`, the `border-bottom` of code
+  spans with an error (`2px red dashed` by default).
+
+- Added CSS shadow part `diagnostic-tooltip` for styling the tooltip that
+  appears when hovering over an error.
+
 ## [0.6.3] - 2021-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -658,6 +658,7 @@ to quickly experiment with themes and other customizations.
 | `--playground-code-TOKEN-color`                    | *various*                                                                                | Color of each kind of `TOKEN` in syntax highlighted-code. See the [syntax highlighting](#syntax-highlighting) section for details. |
 | `--playground-highlight-color`                     | ![](images/colors/6200EE.png) `#6200EE`                                                  | Color of the active file-picker tab label and indicator, and the preview loading bar                                               |
 | `--playground-code-background`                     | ![](images/colors/FFFFFF.png) `#FFFFFF`                                                  | `background` of the code editor                                                                                                    |
+| `--playground-error-border`                        | `2px red dashed`                                                                         | `border-bottom` of code spans with an error                                                                                        |
 | `--playground-tab-bar-background`                  | ![](images/colors/EAEAEA.png) `#EAEAEA`                                                  | `background` of the editor file-picker tab bar                                                                                     |
 | `--playground-tab-bar-foreground-color`            | ![](images/colors/000000.png) `#000000`                                                  | Text `color` of inactive file-picker tabs                                                                                          |
 | `--playground-preview-toolbar-background`          | ![](images/colors/FFFFFF.png) `#FFFFFF`                                                  | `background` of the preview toolbar                                                                                                |
@@ -672,15 +673,16 @@ parts](https://developer.mozilla.org/en-US/docs/Web/CSS/::part) are exported,
 which you can style with additional rules not covered by the above CSS custom
 properties.
 
-| Part name                                   | Exported by      | Description                                  |
-| ------------------------------------------- | ---------------- | -------------------------------------------- |
-| `tab-bar`                                   | `ide`            | Tab bar file switcher                        |
-| `editor`                                    | `ide`            | Editor                                       |
-| `preview`                                   | `ide`            | Preview                                      |
-| `preview-toolbar`                           | `ide`, `preview` | Preview top bar                              |
-| `preview-location`                          | `ide`, `preview` | Preview top bar "Result" heading             |
-| `preview-reload-button`                     | `ide`, `preview` | Preview top bar reload button                |
-| `preview-loading-indicator`                 | `ide`, `preview` | Preview top bar horizontal loading indicator |
+| Part name                                   | Exported by                         | Description                                                               |
+| ------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------- |
+| `tab-bar`                                   | `ide`                               | Tab bar file switcher                                                     |
+| `editor`                                    | `ide`                               | Editor                                                                    |
+| `preview`                                   | `ide`                               | Preview                                                                   |
+| `preview-toolbar`                           | `ide`, `preview`                    | Preview top bar                                                           |
+| `preview-location`                          | `ide`, `preview`                    | Preview top bar "Result" heading                                          |
+| `preview-reload-button`                     | `ide`, `preview`                    | Preview top bar reload button                                             |
+| `preview-loading-indicator`                 | `ide`, `preview`                    | Preview top bar horizontal loading indicator                              |
+| `diagnostic-tooltip`                        | `ide`, `file-editor`, `code-editor` | The tooltip that appears when hovering over a code span that has an error |
 
 # Syntax highlighting
 

--- a/README.md
+++ b/README.md
@@ -533,12 +533,13 @@ project element.
 
 ### Properties
 
-| Name             |  Type          | Default                   | Description                                                                  |
-| ---------------- | -------------- | ------------------------- | ---------------------------------------------------------------------------- |
-| `projectSrc`     | `string`       | `undefined`               | URL of a [project files manifest](#option-2-json-manifest) to load.          |
-| `files`          | `SampleFile[]` | `undefined`               | Get or set the array of project files ([details](#option-3-files-property)). |
-| `sandboxScope`   | `string`       | `"playground-elements"`   | The service worker scope to register on.                                     |
-| `sandboxBaseUrl` | `string`       | _module parent directory_ | Base URL for script execution sandbox ([details](#sandbox)).                 |
+| Name             |  Type                         | Default                   | Description                                                                                               |
+| ---------------- | ----------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------- | --- |
+| `projectSrc`     | `string`                      | `undefined`               | URL of a [project files manifest](#option-2-json-manifest) to load.                                       |
+| `files`          | `SampleFile[]`                | `undefined`               | Get or set the array of project files ([details](#option-3-files-property)).                              |
+| `sandboxScope`   | `string`                      | `"playground-elements"`   | The service worker scope to register on.                                                                  |
+| `sandboxBaseUrl` | `string`                      | _module parent directory_ | Base URL for script execution sandbox ([details](#sandbox)).                                              |
+| `diagnostics`    | `Map<string, lsp.Diagnostic>` | `undefined`               | Map from filename to array of Language Server Protocol diagnostics resulting from the latest compilation. | `   |
 
 ### Methods
 

--- a/configurator/project/project.json
+++ b/configurator/project/project.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "index.html": {},
-    "my-element.ts": {}
+    "my-element.ts": {},
+    "index.html": {}
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "comlink": "^4.3.0",
         "lit-element": "^2.3.1",
         "lit-html": "^1.2.1",
-        "tslib": "^2.0.3"
+        "tslib": "^2.0.3",
+        "vscode-languageserver": "^7.0.0"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.1.5",
@@ -6754,6 +6755,39 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "engines": {
+        "node": ">=8.0.0 || >=10.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.16.0"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "dependencies": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -12518,6 +12552,33 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+    },
+    "vscode-languageserver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+      "requires": {
+        "vscode-languageserver-protocol": "3.16.0"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "requires": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,7 @@
         "@material/mwc-tab": "^0.20.0",
         "@material/mwc-tab-bar": "^0.20.0",
         "@material/mwc-textfield": "^0.20.0",
-        "@types/es-module-lexer": "^0.3.0",
         "comlink": "^4.3.0",
-        "es-module-lexer": "^0.3.26",
         "lit-element": "^2.3.1",
         "lit-html": "^1.2.1",
         "tslib": "^2.0.3"
@@ -1099,11 +1097,6 @@
       "resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.0.tgz",
       "integrity": "sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==",
       "dev": true
-    },
-    "node_modules/@types/es-module-lexer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es-module-lexer/-/es-module-lexer-0.3.0.tgz",
-      "integrity": "sha512-XI3MGSejUQIJ3wzY0i5IHy5J3eb36M/ytgG8jIOssP08ovtRPcjpjXQqrx51AHBNBOisTS/NQNWJitI17+EwzQ=="
     },
     "node_modules/@types/estree": {
       "version": "0.0.39",
@@ -2943,11 +2936,6 @@
       "resolved": "https://registry.npmjs.org/errorstacks/-/errorstacks-2.3.0.tgz",
       "integrity": "sha512-VjCIUbEyLymy2N1M/uTniewz+j69YC2R7Sp1UiJn04RHwyIniBib6hUZwgmphAAZTOk7LRg/wryGFEJhblEd7Q==",
       "dev": true
-    },
-    "node_modules/es-module-lexer": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.26.tgz",
-      "integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA=="
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
@@ -8015,11 +8003,6 @@
       "integrity": "sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==",
       "dev": true
     },
-    "@types/es-module-lexer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@types/es-module-lexer/-/es-module-lexer-0.3.0.tgz",
-      "integrity": "sha512-XI3MGSejUQIJ3wzY0i5IHy5J3eb36M/ytgG8jIOssP08ovtRPcjpjXQqrx51AHBNBOisTS/NQNWJitI17+EwzQ=="
-    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -9522,11 +9505,6 @@
       "resolved": "https://registry.npmjs.org/errorstacks/-/errorstacks-2.3.0.tgz",
       "integrity": "sha512-VjCIUbEyLymy2N1M/uTniewz+j69YC2R7Sp1UiJn04RHwyIniBib6hUZwgmphAAZTOk7LRg/wryGFEJhblEd7Q==",
       "dev": true
-    },
-    "es-module-lexer": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.26.tgz",
-      "integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA=="
     },
     "escape-html": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@rollup/plugin-commonjs": "^17.0.0",
         "@rollup/plugin-node-resolve": "^11.0.0",
         "@rollup/plugin-replace": "^2.3.3",
+        "@types/codemirror": "^0.0.108",
         "@web/dev-server": "^0.1.4",
         "@web/test-runner": "^0.12.2",
         "@web/test-runner-playwright": "^0.8.0",
@@ -1045,6 +1046,15 @@
         "@types/qs": "*"
       }
     },
+    "node_modules/@types/codemirror": {
+      "version": "0.0.108",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
+      "integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
+      "dev": true,
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
     "node_modules/@types/command-line-args": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
@@ -1274,6 +1284,15 @@
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.3.tgz",
+      "integrity": "sha512-imDtS4TAoTcXk0g7u4kkWqedB3E4qpjXzCpD2LU5M5NAXHzCDsypyvXSaG7mM8DKYkCRa7tFp4tS/lp/Wo7Q3w==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
       }
     },
     "node_modules/@types/uuid": {
@@ -7942,6 +7961,15 @@
         "@types/qs": "*"
       }
     },
+    "@types/codemirror": {
+      "version": "0.0.108",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
+      "integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
+      "dev": true,
+      "requires": {
+        "@types/tern": "*"
+      }
+    },
     "@types/command-line-args": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
@@ -8171,6 +8199,15 @@
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
+      }
+    },
+    "@types/tern": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.3.tgz",
+      "integrity": "sha512-imDtS4TAoTcXk0g7u4kkWqedB3E4qpjXzCpD2LU5M5NAXHzCDsypyvXSaG7mM8DKYkCRa7tFp4tS/lp/Wo7Q3w==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
       }
     },
     "@types/uuid": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "comlink": "^4.3.0",
     "lit-element": "^2.3.1",
     "lit-html": "^1.2.1",
-    "tslib": "^2.0.3"
+    "tslib": "^2.0.3",
+    "vscode-languageserver": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,9 +79,7 @@
     "@material/mwc-tab": "^0.20.0",
     "@material/mwc-tab-bar": "^0.20.0",
     "@material/mwc-textfield": "^0.20.0",
-    "@types/es-module-lexer": "^0.3.0",
     "comlink": "^4.3.0",
-    "es-module-lexer": "^0.3.26",
     "lit-element": "^2.3.1",
     "lit-html": "^1.2.1",
     "tslib": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
     "@rollup/plugin-replace": "^2.3.3",
+    "@types/codemirror": "^0.0.108",
     "@web/dev-server": "^0.1.4",
     "@web/test-runner": "^0.12.2",
     "@web/test-runner-playwright": "^0.8.0",

--- a/src/lib/codemirror.ts
+++ b/src/lib/codemirror.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// Our own specialized CodeMirror bundle (see rollup.config.js).
+import '../_codemirror/codemirror-bundle.js';
+
+// Note it's critical we use `import type` here, or else we'll also import the
+// wrong runtime modules.
+import type CodeMirrorCore from 'codemirror';
+import type CoreMirrorFolding from 'codemirror/addon/fold/foldcode.js';
+
+/**
+ * CodeMirror function.
+ *
+ * This function is defined as window.CodeMirror, but @types/codemirror doesn't
+ * declare that.
+ */
+export const CodeMirror = (window as {
+  CodeMirror: typeof CodeMirrorCore & typeof CoreMirrorFolding;
+}).CodeMirror;

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -5,70 +5,8 @@
  */
 
 import {LitElement, customElement, css, property} from 'lit-element';
-
-// TODO(aomarks) We use CodeMirror v5 instead of v6 only because we want support
-// for nested highlighting of HTML and CSS inside JS/TS. Upgrade back to v6 once
-// support is available. See
-// https://github.com/lezer-parser/javascript/issues/3. This module sets a
-// `CodeMirror` global.
-import './_codemirror/codemirror-bundle.js';
+import {CodeMirror} from './lib/codemirror.js';
 import codemirrorStyles from './_codemirror/codemirror-styles.js';
-
-// TODO(aomarks) @types/codemirror exists, but installing it and referencing
-// global `CodeMirror` errors with:
-//
-//  'CodeMirror' refers to a UMD global, but the current file is a module.
-//  Consider adding an import instead
-//
-// Maybe there's a way to get this working. See
-// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/codemirror/index.d.ts
-declare function CodeMirror(
-  callback: (host: HTMLElement) => void,
-  options?: CodeMirrorConfiguration
-): {
-  getValue(): string;
-  setValue(content: string): void;
-  setSize(width?: string | number, height?: string | number): void;
-  refresh(): void;
-  setOption<K extends keyof CodeMirrorConfiguration>(
-    option: K,
-    value: CodeMirrorConfiguration[K]
-  ): void;
-  on(eventName: 'change', handler: () => void): void;
-  getDoc(): CodeMirrorDoc;
-  foldCode(pos: number | CodeMirrorPos, options: CodeMirrorFoldOptions): void;
-};
-
-interface CodeMirrorDoc {
-  posFromIndex(index: number): CodeMirrorPos;
-  markText(
-    from: CodeMirrorPos,
-    to: CodeMirrorPos,
-    options?: CodeMirrorTextMarkerOptions
-  ): void;
-}
-
-interface CodeMirrorPos {
-  ch: number;
-  line: number;
-}
-
-interface CodeMirrorConfiguration {
-  value?: string;
-  mode?: string | null;
-  lineNumbers?: boolean;
-  readOnly?: boolean | 'nocursor';
-}
-
-interface CodeMirrorTextMarkerOptions {
-  collapsed?: boolean;
-  className?: string;
-}
-
-interface CodeMirrorFoldOptions {
-  rangeFinder?: () => void;
-  widget?: string | Element;
-}
 
 // TODO(aomarks) Could we upstream this to lit-element? It adds much stricter
 // types to the ChangedProperties type.

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -160,6 +160,7 @@ export class PlaygroundCodeEditor extends LitElement {
   private _hideOrFoldRegionsActive = false;
   private _cmDom?: HTMLElement;
   private _diagnosticMarkers: Array<CodeMirror.TextMarker> = [];
+  private _diagnosticsMouseoverListenerActive = false;
 
   update(changedProperties: PropertyValues) {
     const cm = this._codemirror;
@@ -410,16 +411,22 @@ export class PlaygroundCodeEditor extends LitElement {
         this._diagnosticMarkers.pop()!.clear();
       }
       if (!this.diagnostics?.length) {
-        this._cmDom?.removeEventListener(
+        if (this._diagnosticsMouseoverListenerActive) {
+          this._cmDom?.removeEventListener(
+            'mouseover',
+            this._onMouseOverWithDiagnostics
+          );
+          this._diagnosticsMouseoverListenerActive = false;
+        }
+        return;
+      }
+      if (!this._diagnosticsMouseoverListenerActive) {
+        this._cmDom?.addEventListener(
           'mouseover',
           this._onMouseOverWithDiagnostics
         );
-        return;
+        this._diagnosticsMouseoverListenerActive = true;
       }
-      this._cmDom?.addEventListener(
-        'mouseover',
-        this._onMouseOverWithDiagnostics
-      );
       for (let i = 0; i < this.diagnostics.length; i++) {
         const diagnostic = this.diagnostics[i];
         this._diagnosticMarkers.push(

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -222,7 +222,13 @@ export class PlaygroundCodeEditor extends LitElement {
     // sometimes be missing, but typing in the editor will fix it.
     if (typeof ResizeObserver === 'function') {
       this._resizeObserver = new ResizeObserver(() => {
+        // Temporarily disconnect to avoid loops, because CodeMirror might
+        // resize itself on refresh.
+        this._resizeObserver?.disconnect();
         this._codemirror?.refresh();
+        requestAnimationFrame(() => {
+          this._resizeObserver?.observe(this);
+        });
       });
       this._resizeObserver.observe(this);
     }
@@ -231,6 +237,7 @@ export class PlaygroundCodeEditor extends LitElement {
 
   disconnectedCallback() {
     this._resizeObserver?.disconnect();
+    this._resizeObserver = undefined;
     super.disconnectedCallback();
   }
 

--- a/src/playground-file-editor.ts
+++ b/src/playground-file-editor.ts
@@ -98,12 +98,14 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
           'filesChanged',
           this._onProjectFilesChanged
         );
+        oldProject.removeEventListener('compileDone', this._onCompileDone);
       }
       if (this._project) {
         this._project.addEventListener(
           'filesChanged',
           this._onProjectFilesChanged
         );
+        this._project.addEventListener('compileDone', this._onCompileDone);
       }
       this._onProjectFilesChanged();
     }
@@ -115,6 +117,7 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
       ${this._files
         ? html`
             <playground-code-editor
+              exportparts="diagnostic-tooltip"
               .value=${
                 // We need live() because the lit's dirty-checking value for
                 // content is not updated by user edits.
@@ -126,6 +129,9 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
               .lineNumbers=${this.lineNumbers}
               .readonly=${!this._currentFile}
               .pragmas=${this.pragmas}
+              .diagnostics=${this._project?.diagnostics?.get(
+                this._currentFile?.name ?? ''
+              )}
               @change=${this._onEdit}
             >
             </playground-code-editor>
@@ -136,6 +142,11 @@ export class PlaygroundFileEditor extends PlaygroundConnectedElement {
 
   private _onProjectFilesChanged = () => {
     this.filename ??= this._files[0]?.name;
+    this.requestUpdate();
+  };
+
+  private _onCompileDone = () => {
+    // Propagate diagnostics.
     this.requestUpdate();
   };
 

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -325,7 +325,8 @@ export class PlaygroundIde extends LitElement {
           exportparts="preview-toolbar,
                        preview-location,
                        preview-reload-button,
-                       preview-loading-indicator"
+                       preview-loading-indicator,
+                       diagnostic-tooltip"
           .project=${projectId}
         ></playground-preview>
       </div>

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import type {Diagnostic} from 'vscode-languageserver';
+
 /**
  * Sent from the project to the proxy, with configuration and a port for further
  * messages.
@@ -60,11 +62,16 @@ export interface ServiceWorkerAPI {
   setFileAPI(fileAPI: FileAPI, sessionID: string): void;
 }
 
+export interface CompileResult {
+  files: Map<string, string>;
+  diagnostics: Map<string, Array<Diagnostic>>;
+}
+
 export interface TypeScriptWorkerAPI {
   compileProject(
     files: Array<SampleFile>,
     importMap: ModuleImportMap
-  ): Promise<Map<string, string>>;
+  ): Promise<CompileResult>;
 }
 
 export interface FileAPI {


### PR DESCRIPTION
- Syntactic and other *basic* TypeScript errors are now shown with red underlines and a tooltip on hover.

- We currently can't show any errors that depend on typings, because we don't fetch them (even the standard libs)! This will require some more work -- tracking separately at https://github.com/PolymerLabs/playground-elements/issues/119 and will send as followup.

- It's using the Language Server Protocol `Diagnostic` type as the interface. Should be good for other diagnostic sources we might add in the future.

- Sadly, we're currently displaying a `border-bottom: 2px dashed red`, instead of `text-decoration: red wavy underline`, because `wavy` doesn't render *anything* for single characters (!): https://bugs.chromium.org/p/chromium/issues/detail?id=668042). Could add a custom implementation of wavy underlines as a followup.

- Try it out at https://polymerlabs.github.io/playground-elements/

<img src="https://user-images.githubusercontent.com/48894/112761185-ebea1480-8fae-11eb-8c05-b19e76a0a215.png" width=600>

Part of https://github.com/PolymerLabs/playground-elements/issues/67