### PR TITLE
Add unknown property errors to temporary typescript error excludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- TypeScript errors of the form `Property '...' does not exist on type '...'`
+  are now suppressed (temporarily until `d.ts` files are fetched).
 
 ## [0.6.6] - 2021-03-29
 

--- a/src/typescript-worker/playground-typescript-worker.ts
+++ b/src/typescript-worker/playground-typescript-worker.ts
@@ -501,4 +501,6 @@ const excludedTypeScriptDiagnosticCodes = new Set<number>([
   2304,
   // Cannot find module '...' or its corresponding type declarations.
   2307,
+  // Property '...' does not exist on type '...'.
+  2339,
 ]);


### PR DESCRIPTION
Temporary exclusion until https://github.com/PolymerLabs/playground-elements/issues/119 is fixed.

Fixes https://github.com/PolymerLabs/playground-elements/issues/121