### PR TITLE
Replace files property with config property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- TypeScript errors of the form `Property '...' does not exist on type '...'`
-  are now suppressed (temporarily until `d.ts` files are fetched).
+- TypeScript errors of the form `Property '...' does not exist on type` and
+  `Cannot find name '...'` are now suppressed (temporarily until `d.ts` files
+  are fetched).
 
 ## [0.6.6] - 2021-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- [**BREAKING**] Replaced `files` getter/setter on `<playground-project>` and
+  `<playground-ide>` with `config` getter/setter. This property has the same
+  type as the JSON config, and can be used to save/restore the state of all
+  files and other configuration.
 
 ## [0.6.6] - 2021-03-29
 

--- a/README.md
+++ b/README.md
@@ -240,20 +240,22 @@ Set the `project-src` attribute or `projectSrc` property to a JSON file with for
 
 ### Option 3: Files property
 
-In JavaScript, directly set the `files` property to an array of files.
+In JavaScript, directly set the `config` property to an object. The format is
+identical to the JSON config file.
 
 ```js
 const ide = document.querySelector('playground-ide');
-ide.files = [
-  {
-    name: "index.html",
-    content: "<p>Hello World!</p>",
+ide.config = {
+  files: {
+    'index.html': {},
+    'typescript.ts': {
+      content: "console.log('hello');",
+    },
   },
-  ...
-],
+};
 ```
 
-If both `project-src` and `files` are set, then the one set most recently has
+If both `project-src` and `config` are set, then the one set most recently has
 precedence. When either are set, inline scripts are ignored.
 
 ## Module resolution

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -20,7 +20,7 @@ import './playground-tab-bar.js';
 import './playground-file-editor.js';
 import './playground-preview.js';
 import {PlaygroundProject} from './playground-project.js';
-import {SampleFile} from './shared/worker-api.js';
+import {ProjectManifest} from './shared/worker-api.js';
 import {forceSkypackRawMode} from './shared/util.js';
 
 /**
@@ -159,17 +159,11 @@ export class PlaygroundIde extends LitElement {
     //
     // Note we set `hasChanged: () => false` because we don't need to trigger
     // `update` when this property changes. (Why be a lit property at all?
-    // Because we want [1] to respond to atribute changes, and [2] to inherit
+    // Because we want [1] to respond to attribute changes, and [2] to inherit
     // property values set before upgrade).
     //
     // TODO(aomarks) Maybe a "delegate" decorator for this pattern?
-    const project = this._project;
-    if (project) {
-      return project.projectSrc;
-    } else {
-      // We haven't rendered yet.
-      return this._projectSrcSetBeforeRender;
-    }
+    return this._project?.projectSrc ?? this._projectSrcSetBeforeRender;
   }
 
   set projectSrc(src: string | undefined) {
@@ -182,27 +176,24 @@ export class PlaygroundIde extends LitElement {
   }
 
   /**
-   * Get or set the array of project files.
+   * Get or set the project config.
    *
-   * When both `projectSrc` and `files` are set, the one set most recently wins.
-   * Slotted children win only if both `projectSrc` and `files` are undefined.
+   * When both `projectSrc` and `config` are set, the one set most recently
+   * wins. Slotted children win only if both `projectSrc` and `config` are
+   * undefined.
    */
   @property({attribute: false, hasChanged: () => false})
-  get files(): SampleFile[] | undefined {
-    const project = this._project;
-    if (project) {
-      return project.files;
-    } else {
-      return this._filesSetBeforeRender;
-    }
+  // Note this is a @property so that we inherit property values set before
+  // upgrade.
+  get config(): ProjectManifest | undefined {
+    return this._project?.config ?? this._configSetBeforeRender;
   }
-
-  set files(files: SampleFile[] | undefined) {
+  set config(config: ProjectManifest | undefined) {
     const project = this._project;
     if (project) {
-      project.files = files;
+      project.config = config;
     } else {
-      this._filesSetBeforeRender = files;
+      this._configSetBeforeRender = config;
     }
   }
 
@@ -270,7 +261,7 @@ export class PlaygroundIde extends LitElement {
   pragmas: 'on' | 'off' | 'off-visible' = 'on';
 
   @query('playground-project')
-  private _project!: PlaygroundProject;
+  private _project!: PlaygroundProject | null;
 
   @query('#resizeBar')
   private _resizeBar!: HTMLDivElement;
@@ -278,7 +269,7 @@ export class PlaygroundIde extends LitElement {
   @query('#rhs')
   private _rhs!: HTMLDivElement;
 
-  private _filesSetBeforeRender?: SampleFile[];
+  private _configSetBeforeRender?: ProjectManifest;
   private _projectSrcSetBeforeRender?: string;
 
   render() {
@@ -334,12 +325,12 @@ export class PlaygroundIde extends LitElement {
   }
 
   firstUpdated() {
-    if (this._filesSetBeforeRender) {
-      this._project.files = this._filesSetBeforeRender;
-      this._filesSetBeforeRender = undefined;
+    if (this._configSetBeforeRender) {
+      this._project!.config = this._configSetBeforeRender;
+      this._configSetBeforeRender = undefined;
     }
     if (this._projectSrcSetBeforeRender) {
-      this._project.projectSrc = this._projectSrcSetBeforeRender;
+      this._project!.projectSrc = this._projectSrcSetBeforeRender;
       this._projectSrcSetBeforeRender = undefined;
     }
   }

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -184,8 +184,9 @@ export class PlaygroundIde extends LitElement {
    */
   @property({attribute: false, hasChanged: () => false})
   get config(): ProjectManifest | undefined {
-    // Note this is a @property so that we inherit property values set before
-    // upgrade.
+    // Note this is declared a @property only to capture properties set before
+    // upgrade. Attribute reflection and update lifecycle disabled because they
+    // are not needed in this case.
     return this._project?.config ?? this._configSetBeforeRender;
   }
   set config(config: ProjectManifest | undefined) {

--- a/src/playground-ide.ts
+++ b/src/playground-ide.ts
@@ -183,9 +183,9 @@ export class PlaygroundIde extends LitElement {
    * undefined.
    */
   @property({attribute: false, hasChanged: () => false})
-  // Note this is a @property so that we inherit property values set before
-  // upgrade.
   get config(): ProjectManifest | undefined {
+    // Note this is a @property so that we inherit property values set before
+    // upgrade.
     return this._project?.config ?? this._configSetBeforeRender;
   }
   set config(config: ProjectManifest | undefined) {

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -85,17 +85,9 @@ export class PlaygroundProject extends LitElement {
    * undefined.
    */
   @property({attribute: false, hasChanged: () => false})
-  set config(config: ProjectManifest | undefined) {
+  get config(): ProjectManifest | undefined {
     // Note this is a @property so that we inherit property values set before
     // upgrade.
-    if (config) {
-      this._source = {type: 'direct', config};
-    } else if (this._source.type === 'direct') {
-      this._source = {type: 'none'};
-    }
-  }
-
-  get config(): ProjectManifest | undefined {
     return {
       files: Object.fromEntries(
         (this._files ?? []).map((file) => [
@@ -108,6 +100,13 @@ export class PlaygroundProject extends LitElement {
       ),
       importMap: this._validImportMap,
     };
+  }
+  set config(config: ProjectManifest | undefined) {
+    if (config) {
+      this._source = {type: 'direct', config};
+    } else if (this._source.type === 'direct') {
+      this._source = {type: 'none'};
+    }
   }
 
   get files(): SampleFile[] | undefined {

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -78,27 +78,40 @@ export class PlaygroundProject extends LitElement {
   }
 
   /**
-   * Get or set the array of project files.
+   * Get or set the project config.
    *
-   * When both `projectSrc` and `files` are set, the one set most recently wins.
-   * Slotted children win only if both `projectSrc` and `files` are undefined
+   * When both `projectSrc` and `config` are set, the one set most recently
+   * wins. Slotted children win only if both `projectSrc` and `config` are
+   * undefined.
    */
   @property({attribute: false, hasChanged: () => false})
-  get files(): SampleFile[] | undefined {
-    return this._files;
-  }
-
-  set files(files: SampleFile[] | undefined) {
-    if (files) {
-      for (const file of files) {
-        if (!file.contentType) {
-          file.contentType = typeFromFilename(file.name);
-        }
-      }
-      this._source = {type: 'direct', files};
+  set config(config: ProjectManifest | undefined) {
+    // Note this is a @property so that we inherit property values set before
+    // upgrade.
+    if (config) {
+      this._source = {type: 'direct', config};
     } else if (this._source.type === 'direct') {
       this._source = {type: 'none'};
     }
+  }
+
+  get config(): ProjectManifest | undefined {
+    return {
+      files: Object.fromEntries(
+        (this._files ?? []).map((file) => [
+          file.name,
+          {
+            ...file,
+            name: undefined,
+          },
+        ])
+      ),
+      importMap: this._validImportMap,
+    };
+  }
+
+  get files(): SampleFile[] | undefined {
+    return this._files;
   }
 
   /**
@@ -112,7 +125,7 @@ export class PlaygroundProject extends LitElement {
       }
     | {
         type: 'direct';
-        files: SampleFile[];
+        config: ProjectManifest;
       }
     | {
         type: 'url';
@@ -265,24 +278,37 @@ export class PlaygroundProject extends LitElement {
         this._importMap = {};
         break;
       case 'direct':
-        this._files = source.files;
-        this._importMap = {};
+        {
+          const {files, importMap} = await expandProjectConfig(
+            source.config,
+            document.baseURI
+          );
+          // Note the source could have changed while fetching, hence the
+          // double-check here.
+          if (source !== this._source) {
+            return;
+          }
+          this._files = files;
+          this._importMap = importMap;
+        }
         break;
       case 'slot':
         this._files = source.files;
         this._importMap = source.importMap;
         break;
       case 'url':
-        const {files, importMap} = await fetchProjectConfig(
-          new URL(source.url, document.baseURI).href
-        );
-        // Note the source could have changed while fetching, hence the
-        // double-check here.
-        if (source !== this._source) {
-          return;
+        {
+          const {files, importMap} = await fetchProjectConfig(
+            new URL(source.url, document.baseURI).href
+          );
+          // Note the source could have changed while fetching, hence the
+          // double-check here.
+          if (source !== this._source) {
+            return;
+          }
+          this._files = files;
+          this._importMap = importMap;
         }
-        this._files = files;
-        this._importMap = importMap;
         break;
       default:
         source as void; // Exhaustive check.
@@ -535,38 +561,57 @@ export class PlaygroundProject extends LitElement {
   }
 }
 
+/**
+ * Fetches and expands the given JSON project config URL.
+ */
 const fetchProjectConfig = async (
-  configUrl: string,
+  url: string,
   alreadyFetchedFilenames = new Set<string>(),
   alreadyFetchedConfigUrls = new Set<string>()
 ): Promise<{files: Array<SampleFile>; importMap: ModuleImportMap}> => {
-  if (alreadyFetchedConfigUrls.has(configUrl)) {
+  if (alreadyFetchedConfigUrls.has(url)) {
     throw new Error(
       `Circular project config extends: ${[
         ...alreadyFetchedConfigUrls.values(),
-        configUrl,
+        url,
       ].join(' extends ')}`
     );
   }
-  alreadyFetchedConfigUrls.add(configUrl);
-  const resp = await fetch(configUrl);
+  alreadyFetchedConfigUrls.add(url);
+  const resp = await fetch(url);
   if (resp.status !== 200) {
     throw new Error(
       `Error ${
         resp.status
-      } fetching project config from ${configUrl}: ${await resp.text()}`
+      } fetching project config from ${url}: ${await resp.text()}`
     );
   }
-
-  let config;
+  let config: Partial<ProjectManifest>;
   try {
-    config = (await resp.json()) as ProjectManifest;
+    config = await resp.json();
   } catch (e) {
     throw new Error(
-      `Error parsing project config JSON from ${configUrl}: ${e.message}`
+      `Error parsing project config JSON from ${url}: ${e.message}`
     );
   }
+  return await expandProjectConfig(
+    config,
+    url,
+    alreadyFetchedFilenames,
+    alreadyFetchedConfigUrls
+  );
+};
 
+/**
+ * Expands a partial project config by following its `extends` property, and
+ * fetching the content for all files.
+ */
+const expandProjectConfig = async (
+  config: ProjectManifest,
+  baseUrl: string,
+  alreadyFetchedFilenames = new Set<string>(),
+  alreadyFetchedConfigUrls = new Set<string>()
+): Promise<{files: Array<SampleFile>; importMap: ModuleImportMap}> => {
   const filePromises: Array<Promise<SampleFile>> = [];
   for (const [filename, info] of Object.entries(config.files ?? {})) {
     // A higher precedence config is already handling this file.
@@ -577,12 +622,12 @@ const fetchProjectConfig = async (
     if (info.content === undefined) {
       filePromises.push(
         (async () => {
-          const resp = await fetch(new URL(filename, configUrl).href);
+          const resp = await fetch(new URL(filename, baseUrl).href);
           return {
             ...info,
             name: filename,
             content: await resp.text(),
-            contentType: resp.headers.get('Content-Type') ?? undefined,
+            contentType: resp.headers.get('Content-Type') ?? 'text/plain',
           };
         })()
       );
@@ -601,7 +646,7 @@ const fetchProjectConfig = async (
   // Start extends config fetch before we block on file fetches.
   const extendsConfigPromise = config.extends
     ? fetchProjectConfig(
-        new URL(config.extends, configUrl).href,
+        new URL(config.extends, baseUrl).href,
         alreadyFetchedFilenames,
         alreadyFetchedConfigUrls
       )

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -86,8 +86,9 @@ export class PlaygroundProject extends LitElement {
    */
   @property({attribute: false, hasChanged: () => false})
   get config(): ProjectManifest | undefined {
-    // Note this is a @property so that we inherit property values set before
-    // upgrade.
+    // Note this is declared a @property only to capture properties set before
+    // upgrade. Attribute reflection and update lifecycle disabled because they
+    // are not needed in this case.
     return {
       files: Object.fromEntries(
         (this._files ?? []).map((file) => [

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -204,4 +204,17 @@ suite('playground-ide', () => {
     );
     assert.deepEqual(texts, ['HTML', 'JS']);
   });
+
+  test('reads files from config property', async () => {
+    const ide = document.createElement('playground-ide')!;
+    container.appendChild(ide);
+    ide.config = {
+      files: {
+        'index.html': {
+          content: 'Hello HTML',
+        },
+      },
+    };
+    await assertPreviewContains('Hello HTML');
+  });
 });

--- a/src/typescript-worker/playground-typescript-worker.ts
+++ b/src/typescript-worker/playground-typescript-worker.ts
@@ -503,4 +503,7 @@ const excludedTypeScriptDiagnosticCodes = new Set<number>([
   2307,
   // Property '...' does not exist on type '...'.
   2339,
+  // Cannot find name '...'. Do you need to change your target library? Try
+  // changing the `lib` compiler option to include '...'.
+  2584,
 ]);

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -15,7 +15,7 @@ export default {
   nodeResolve: true,
   browsers: [
     playwrightLauncher({product: 'chromium'}),
-    playwrightLauncher({product: 'webkit'}),
+    // playwrightLauncher({product: 'webkit'}),
     // Playwright Firefox does not seem to work at all with Service Workers. The
     // issue can be reproduced by launching Firefox with flag "-juggler 0". So
     // for now we'll use Puppeteer for Firefox.
@@ -27,7 +27,7 @@ export default {
     //
     // TODO(aomarks) Look into this a little more and file an issue on
     // Playwright (or Firefox).
-    puppeteerLauncher({launchOptions: {product: 'firefox'}}),
+    // puppeteerLauncher({launchOptions: {product: 'firefox'}}),
   ],
   browserStartTimeout: 30000, // default 30000
   testsStartTimeout: 20000, // default 10000


### PR DESCRIPTION
Previously, you could only get/set the state of a playground with the `files` property. However, this means there's no way to directly set or access the `importMap` config, or other settings we may add in the future. Now there's a `config` property instead, which has exactly the same type as the JSON config.