### PR TITLE
Error tooltips use --playground-code-font-family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
+## Unreleased
+
+### Changed
+
+- Error tooltips now follow `--playground-code-font-family`.
+
 ## [0.9.2] - 2021-04-26
 
 ### Changed

--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -113,6 +113,7 @@ export class PlaygroundCodeEditor extends LitElement {
         position: absolute;
         padding: 7px;
         z-index: 4;
+        font-family: var(--playground-code-font-family, monospace);
       }
 
       #tooltip > div {


### PR DESCRIPTION
Fixes error tooltips to use the `--playground-code-font-family` property and default to `monospace`.

Before:
![image](https://user-images.githubusercontent.com/48894/116122047-1eeafb00-a676-11eb-8bcc-618dbff18826.png)

After:
![image](https://user-images.githubusercontent.com/48894/116122097-2dd1ad80-a676-11eb-997c-50f8ede341c8.png)

