### PR TITLE
Be more responsive when compiles are fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Error tooltips now follow `--playground-code-font-family`.
+- Optimized the UX for fast compile and display by switching to a leading edge
+  debouncer and eliminating the minimum display time for the loading bar.
 
 ## [0.9.2] - 2021-04-26
 

--- a/src/playground-preview.ts
+++ b/src/playground-preview.ts
@@ -212,45 +212,15 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
     this._iframe.src = '';
     this._iframe.src = this._indexUrl;
     this._loading = true;
-    this._startLoadingBar();
+    this._showLoadingBar = true;
   };
-
-  private _startLoadingBarTime = 0;
-  private _stopLoadingBarTimerId?: ReturnType<typeof setTimeout>;
-
-  private _startLoadingBar() {
-    if (this._stopLoadingBarTimerId !== undefined) {
-      clearTimeout(this._stopLoadingBarTimerId);
-      this._stopLoadingBarTimerId = undefined;
-    }
-    if (this._showLoadingBar === false) {
-      this._showLoadingBar = true;
-      this._startLoadingBarTime = performance.now();
-    }
-  }
-
-  private _stopLoadingBar() {
-    if (this._showLoadingBar === false) {
-      return;
-    }
-    // We want to ensure the loading indicator is visible for some minimum
-    // amount of time, or else it might not display at all on a fast reload, or
-    // might only display for a brief flash.
-    const elapsed = performance.now() - this._startLoadingBarTime;
-    const minimum = 500;
-    const pending = Math.max(0, minimum - elapsed);
-    this._stopLoadingBarTimerId = setTimeout(() => {
-      this._showLoadingBar = false;
-      this._stopLoadingBarTimerId = undefined;
-    }, pending);
-  }
 
   async firstUpdated() {
     // Loading should be initially indicated only when we're not pre-rendering,
     // because in that case there should be no visible change once the actual
     // iframe loads, and the indicator is distracting.
     if (this._loading && !this._slotHasAnyVisibleChildren()) {
-      this._startLoadingBar();
+      this._showLoadingBar = true;
     }
 
     // The latest version of MWC forwards the aria-label attribute to the
@@ -290,7 +260,7 @@ export class PlaygroundPreview extends PlaygroundConnectedElement {
       // before "src" is set.
       this._loading = false;
       this._loadedAtLeastOnce = true;
-      this._stopLoadingBar();
+      this._showLoadingBar = false;
     }
   }
 }


### PR DESCRIPTION
Currently, due to the use of a trailing edge debouncer, it takes a
minimum of 300ms between the user making an edit and the result
displaying on screen. However, in many cases we can complete an
edit -> compile -> display pipeline in just a few dozen ms.

This – combined with displaying an attention-getting animated progress
bar for a full half second – makes the playground feel less
responsive than it could be.

This change makes some changes to optimize the UX for fast compiles.

- Change from a trailing edge debouncer to leading edge, so the
  system responds as fast as possible to the first change made.
- If there is a pending compile, start it the moment the previous
  compile finishes. This is somewhat more wasteful, particularly
  for slow compiles, but displays more intermediate states, reducing
  the delta between the displayed code and the displayed preview.
- Removes the minimum display time for the progress bar. Currently
  the progress bar is often the most prominent part of the preview,
  since it's animated, and is displayed for a minimum of half a second.
  I think it's better for the focus to be on the preview contents,
  with the progress bar only displaying when necessary to
  indicate that a preview is loading.