### PR TITLE
Add a WTR plugin for simulating CDNs like unpkg.com

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@rollup/plugin-commonjs": "^19.0.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
         "@rollup/plugin-replace": "^2.3.3",
+        "@types/semver": "^7.3.6",
         "@web/dev-server": "^0.1.4",
         "@web/test-runner": "^0.13.4",
         "@web/test-runner-playwright": "^0.8.0",
@@ -44,6 +45,7 @@
         "rollup-plugin-node-polyfills": "^0.2.1",
         "rollup-plugin-summary": "^1.2.3",
         "rollup-plugin-terser": "^7.0.2",
+        "semver": "^7.3.5",
         "tsc-watch": "^4.2.3",
         "typescript": "^4.1.0-beta"
       }
@@ -1245,6 +1247,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.6.tgz",
+      "integrity": "sha512-0caWDWmpCp0uifxFh+FaqK3CuZ2SkRR/ZRxAV5+zNdC3QVUi6wyOJnefhPvtNt8NQWXB5OA93BUvZsXpWat2Xw==",
+      "dev": true
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.9",
@@ -8016,6 +8024,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/semver": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.6.tgz",
+      "integrity": "sha512-0caWDWmpCp0uifxFh+FaqK3CuZ2SkRR/ZRxAV5+zNdC3QVUi6wyOJnefhPvtNt8NQWXB5OA93BUvZsXpWat2Xw==",
+      "dev": true
     },
     "@types/serve-static": {
       "version": "1.13.9",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-replace": "^2.3.3",
+    "@types/semver": "^7.3.6",
     "@web/dev-server": "^0.1.4",
     "@web/test-runner": "^0.13.4",
     "@web/test-runner-playwright": "^0.8.0",
@@ -69,6 +70,7 @@
     "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-summary": "^1.2.3",
     "rollup-plugin-terser": "^7.0.2",
+    "semver": "^7.3.5",
     "tsc-watch": "^4.2.3",
     "typescript": "^4.1.0-beta"
   },

--- a/src/test/fake-cdn-plugin.ts
+++ b/src/test/fake-cdn-plugin.ts
@@ -19,16 +19,18 @@ import semver from 'semver';
  *
  *    const cdnData = {
  *      "foo": {
- *        "1.2.3": {
- *          "files": {
- *            "package.json": {
- *              "content": `{
- *                "main": "lib/index.js"
- *              }`
- *            },
- *            "lib/index.js": {
- *              "content": "console.log('hello');"
- *            },
+ *        "versions": {
+ *          "1.2.3": {
+ *            "files": {
+ *              "package.json": {
+ *                "content": `{
+ *                  "main": "lib/index.js"
+ *                }`
+ *              },
+ *              "lib/index.js": {
+ *                "content": "console.log('hello');"
+ *              },
+ *            }
  *          }
  *        }
  *      }
@@ -110,6 +112,11 @@ export function fakeCdnPlugin(): TestRunnerPlugin {
         return undefined;
       }
       if (version !== semverRange) {
+        // The version in the URL was a range, rather than a concrete version.
+        // Redirect to the concrete version's URL. Note that redirecting here,
+        // rather than just serving the resolved file directly, is an important
+        // behavior of unpkg that we want to preserve in tests, because we rely
+        // on being able to extract resolved versions from redirect URLs.
         ctx.response.status = 302;
         ctx.response.redirect(`${pathPrefix}${id}/${pkg}@${version}/${path}`);
         return undefined;

--- a/src/test/fake-cdn-plugin.ts
+++ b/src/test/fake-cdn-plugin.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import type {TestRunnerPlugin} from '@web/test-runner-core/dist/server/TestRunnerPlugin.js';
+import semver from 'semver';
+
+/**
+ * A plugin for @web/test-runner that simulates an NPM CDN like unpkg.com. It
+ * extends the built-in @web/test-runner server, and can be re-configured from
+ * the test suite itself between each test using a server command
+ * (https://modern-web.dev/docs/test-runner/commands/).
+ *
+ * Usage:
+ *
+ *    import {executeServerCommand} from '@web/test-runner-commands';
+ *
+ *    const cdnData = {
+ *      "foo": {
+ *        "1.2.3": {
+ *          "main": "lib/index.js",
+ *          "files": {
+ *            "lib/index.js": {
+ *              "content": "console.log('hello');"
+ *            }
+ *          }
+ *        }
+ *      }
+ *    };
+ *    const cdnBaseUrl = await executeServerCommand('set-fake-cdn-data', cdnData);
+ *    // Redirects to <cdnBaseUrl>/foo@1.2.3/lib/index.js and serves its content.
+ *    const result = await fetch(new URL("foo@^1.0.0", cdnBaseUrl).href);
+ */
+export function fakeCdnPlugin(): TestRunnerPlugin {
+  const pathPrefix = '/fake-cdn/';
+  let baseUrl: string | undefined;
+  let data: CdnData = {};
+
+  return {
+    name: 'fake-cdn',
+
+    serverStart(args) {
+      baseUrl = `http://${args.config.hostname}:${args.config.port}${pathPrefix}`;
+    },
+
+    executeCommand({command, payload}) {
+      if (command === 'set-fake-cdn-data') {
+        data = payload as CdnData;
+        return baseUrl;
+      }
+      return false;
+    },
+
+    serve(ctx) {
+      if (!ctx.path.startsWith(pathPrefix)) {
+        return undefined;
+      }
+      const specifier = decodeURIComponent(ctx.path.slice(pathPrefix.length));
+      const parsed = parseNpmModuleSpecifier(specifier);
+      if (!parsed) {
+        ctx.response.status = 404;
+        return undefined;
+      }
+      const {pkg, semverRangeOrTag, path} = parsed;
+      const packageData = data[pkg];
+      if (!packageData) {
+        ctx.response.status = 404;
+        return undefined;
+      }
+      // Note we don't support tags other than "latest" for now, but we could
+      // easily add that to CdnData if needed.
+      const semverRange =
+        semverRangeOrTag === '' || semverRangeOrTag === 'latest'
+          ? '*'
+          : semverRangeOrTag;
+      const versions = Object.keys(packageData.versions);
+      const version = semver.maxSatisfying(versions, semverRange);
+      if (!version) {
+        ctx.response.status = 404;
+        return undefined;
+      }
+      if (version !== semverRange) {
+        ctx.response.status = 302;
+        ctx.response.redirect(`${pathPrefix}${pkg}@${version}/${path}`);
+        return undefined;
+      }
+      const versionData = packageData.versions[version];
+      if (!versionData) {
+        ctx.response.status = 404;
+        return undefined;
+      }
+      if (path === '') {
+        ctx.response.status = 302;
+        ctx.response.redirect(
+          `${pathPrefix}${pkg}@${version}/${versionData.main ?? 'index.js'}`
+        );
+        return undefined;
+      }
+      const file = versionData.files[path];
+      if (!file) {
+        ctx.response.status = 404;
+        return undefined;
+      }
+      return {
+        body: file.content,
+        type: path.endsWith('.js')
+          ? 'text/javascript'
+          : path.endsWith('.json')
+          ? 'application/json'
+          : 'text/plain',
+      };
+    },
+  };
+}
+
+export type CdnData = {
+  [pkg: string]: {
+    versions: {
+      [version: string]: {
+        main?: string;
+        files: {
+          [path: string]: {
+            content: string;
+          };
+        };
+      };
+    };
+  };
+};
+
+const parseNpmModuleSpecifier = (
+  specifier: string
+): {pkg: string; semverRangeOrTag: string; path: string} | undefined => {
+  const match = specifier.match(
+    /^((?:@[^\/@]+\/)?[^\/\@]+)(?:@([^\/]+))?\/?(.*)$/
+  );
+  if (match === null) {
+    return undefined;
+  }
+  const [, pkg, semverRangeOrTag, path] = match;
+  return {pkg, semverRangeOrTag, path};
+};

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -6,6 +6,7 @@
 
 import {playwrightLauncher} from '@web/test-runner-playwright';
 import {puppeteerLauncher} from '@web/test-runner-puppeteer';
+import {fakeCdnPlugin} from './test/fake-cdn-plugin.js';
 
 // https://modern-web.dev/docs/test-runner/cli-and-configuration/
 export default {
@@ -39,4 +40,5 @@ export default {
       timeout: '30000', // default 2000
     },
   },
+  plugins: [fakeCdnPlugin()],
 };


### PR DESCRIPTION
This will be useful for testing an upcoming PR that proxies unpkg.com so that we can control the module specifiers of dependencies (https://github.com/PolymerLabs/playground-elements/issues/104).

It's a plugin for @web/test-runner that simulates an NPM CDN like unpkg.com. It extends the built-in @web/test-runner server, and can be re-configured from the test suite itself between each test using a server command (https://modern-web.dev/docs/test-runner/commands/).

Usage:

```ts
import {executeServerCommand} from '@web/test-runner-commands';

const cdnData = {
  "foo": {
    "1.2.3": {
      "main": "lib/index.js",
      "files": {
        "lib/index.js": {
          "content": "console.log('hello');"
        }
      }
    }
  }
};
const cdnBaseUrl = await executeServerCommand('set-fake-cdn-data', cdnData);
// Redirects to <cdnBaseUrl>/foo@1.2.3/lib/index.js and serves its content.
const result = await fetch(new URL("foo@^1.0.0", cdnBaseUrl).href);
 ```