### PR TITLE
Ignore query params when serving playground files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   compilation to completely finish, and each `.js` file is served as it
   compiles.
 
+### Fixed
+
+- Query parameters are now ignored when serving files from the virtual file
+  system.
+
 ## [0.9.4] - 2021-05-18
 
 ### Fixed

--- a/src/service-worker/playground-service-worker.ts
+++ b/src/service-worker/playground-service-worker.ts
@@ -107,9 +107,10 @@ const onFetch = (e: FetchEvent) => {
 
 const parseScopedUrl = (url: string) => {
   const scope = self.registration.scope;
-  // URLs in scope will be of the form: {scope}{sessionId}/{filePath}
-  // scope is always a full URL prefix, including a trailing slash
-  const sessionAndPath = url.substring(scope.length);
+  // URLs in scope will be of the form: {scope}{sessionId}/{filePath}. Scope is
+  // always a full URL prefix, including a trailing slash. Strip query params or
+  // else the filename won't match.
+  const sessionAndPath = url.substring(scope.length).split('?')[0];
   const slashIndex = sessionAndPath.indexOf('/');
   let sessionId, filePath: string | undefined;
   if (slashIndex === -1) {

--- a/src/test/playground-ide_test.ts
+++ b/src/test/playground-ide_test.ts
@@ -349,4 +349,21 @@ suite('playground-ide', () => {
     assert.isFalse(editableRegion.matches(':focus'));
     assert.notInclude(focusContainer.textContent, keyboardHelp);
   });
+
+  test('ignores query params when serving files', async () => {
+    const ide = document.createElement('playground-ide');
+    ide.sandboxBaseUrl = '/';
+    ide.config = {
+      files: {
+        'index.html': {
+          content: '<script>location.assign("./foo.html?xyz");</script>',
+        },
+        'foo.html': {
+          content: 'foo.html loaded',
+        },
+      },
+    };
+    container.appendChild(ide);
+    await assertPreviewContains('foo.html loaded');
+  });
 });


### PR DESCRIPTION
Previously we were matching filenames using the pathname + query params, due to the way we parsed URLs in the service worker, so we would serve 404s if there were query params. Now we strip query params.