### PR TITLE
Set Origin-Agent-Cluster header in service worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- The service worker now sets the `Origin-Agent-Cluster: ?1` heading on all
+  responses, to encourage browsers to allocate a separate process or thread for
+  Playground preview iframe under certain conditions. See the [Process
+  isolation](https://github.com/PolymerLabs/playground-elements#process-isolation)
+  section of the README for more details.
 
 ## [0.10.1] - 2021-07-14
 

--- a/README.md
+++ b/README.md
@@ -563,6 +563,11 @@ meets all of the following requirements:
    modifying the parent window using `window.parent`, e.g. to change your
    sign-in link to a malicious URL.
 
+   > NOTE: It is highly recommended to furthermore use either an entirely
+   > different _site_, or to use the `Origin-Agent-Cluster` header, to improve
+   > performance and prevent lockups. See [Process
+   > isolation](#process-isolation) for more information.
+
 2. Must not have access to any sensitive cookies. This prevents untrusted code
    from e.g. reading and forwarding your user's authentication token.
 
@@ -579,6 +584,29 @@ meets all of the following requirements:
    components_:
    - `playground-service-worker.js`
    - `playground-service-worker-proxy.html`
+
+#### Process isolation
+
+Some browsers such as Chrome are sometimes able to allocate a separate process
+or thread for iframes. This is highly desirable for Playground, because it
+improves responsiveness and prevents full lockups (resulting from e.g. an
+infinite loop accidentally written by a user).
+
+By default, this iframe process isolation can only occur if the iframe and the
+parent window are _different sites_. While an _origin_ is defined by (protocol +
+subdomain + top-level domain + port), a _site_ is defined only by (protocol +
+top-level domain). For example, `example.com` and `foo.example.com` are
+different-origin but same-site, whereas `example.com` and `example.net` are
+different-origin and different-site.
+
+Alternatively, if the `Origin-Agent-Cluster: ?1` header is set on all server
+responses from one or the other origins, then iframe process isolation can also
+occur with different-origin but same-site configurations. Note that this header
+must truly be set on _all_ responses from the origin, because the browser will
+remember the setting based on the _first response_ it gets from that origin. See
+_["Requesting performance isolation with the Origin-Agent-Cluster
+header"](https://web.dev/origin-agent-cluster/)_ for more information about this
+header.
 
 ## Components
 


### PR DESCRIPTION
Chrome (and maybe only Chrome currently) is able to allocate a separate process or thread to iframes, but only if the iframe and the parent are on separate *sites*, where a site is defined by protocol + top-level domain (note this does *not* include subdomains).

This is the main root cause of https://github.com/lit/lit.dev/issues/411. I had mistakenly assumed that since `lit.dev` and `playground.lit.dev` are separate origins, Chrome would execute Playground preview iframes in separate processes. But in fact it cannot, because those origins are same-site.

However, there is a new header called `Origin-Agent-Cluster`, which allows a server to switch the key for process isolation from site to origin. See https://web.dev/origin-agent-cluster/

This PR adds that header to service worker responses, and documents this issue for people who choose to change the default sandbox origin from unpkg to their own.

For playground.lit.dev, we'll also need to update the server itself to send this header, since it's actually the *first* response from an origin that determines this setting (I'm not actually sure yet exactly how long it persists for). Done in https://github.com/lit/lit.dev/pull/418.

See also:
https://www.chromium.org/developers/design-documents/oop-iframes
https://html.spec.whatwg.org/multipage/origin.html#origin-keyed-agent-clusters