### PR TITLE
Dependency handling refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,30 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixes duplicate module errors by canonicalizing all import specifiers. Import
+  specifiers are now canonicalized by version number and default module. This
+  applies both to local project files, and throughout the entire external
+  dependency tree.
+
+- Import maps now apply to modules in external dependencies, not just to local
+  project files.
+
+### Changed
+
+- If the project contains a `package.json` file, then its
+  [`dependencies`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#dependencies)
+  field will be used to determine the version of dependencies (just like how NPM
+  works locally).
+
+- Dependencies are now served from the special
+  "<service-worker-scope>/node_modules/..." path, instead of directly from
+  `https://unpkg.com/...?module` URLs. Behind-the-scenes, dependencies are still
+  fetched from unpkg, but they are now themselves transformed to ensure correct
+  specifier canonicalization.
 
 ## [0.11.0] - 2021-07-28
 

--- a/README.md
+++ b/README.md
@@ -256,19 +256,45 @@ precedence. When either are set, inline scripts are ignored.
 ## Module resolution
 
 By default, bare module specifiers in JavaScript and TypeScript files are
-transformed to `unpkg.com` URLs:
+transformed to special `./node_modules/` URLs, and fetched behind-the-scenes
+from unpkg.com at the latest version.
 
 ```js
-// What you write
+// What you write:
 import {html} from 'lit-html';
 
-// What playground serves
-import {html} from 'https://unpkg.com/lit-html?module';
+// What playground serves:
+import {html} from './node_modules/lit-html@1.4.1/lit-html.js';
+
+// What playground fetches behind-the-scenes:
+// https://unpkg.com/lit-html@latest/lit-html.js
 ```
 
-To customize module resolution you can configure an _import map_. You may want
-to do this to pin a specific version, change CDNs, or point to a locally served
-copy of a module:
+### `package.json`
+
+To customize the version of a module you import, create a file called
+`package.json` in your project containing a
+[`dependencies`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#dependencies)
+map. This works exactly like it does when using NPM locally.
+
+```json
+{
+  "dependencies": {
+    "lit-html": "^2.0.0-rc.3"
+  }
+}
+```
+
+> TIP: Use the `hidden` [attribute](#option-1-inline-scripts) or
+> [property](#option-2-json-configuration) to hide the `package.json` file from
+> being displayed in the list of project files, if you don't want the end-user
+> to be able to see or modify it.
+
+### Import maps
+
+For full control over module resolution, you can configure an _import map_. You
+may want to do this to change CDNs or point to a locally served copy of a
+module:
 
 ```js
 {

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -505,7 +505,7 @@ export class PlaygroundProject extends LitElement {
     }
     workerApi.compileProject(
       this._files ?? [],
-      this._importMap,
+      {importMap: this._importMap},
       proxy((result) => build.onOutput(result))
     );
     await build.stateChange;

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -75,7 +75,10 @@ export interface ServiceWorkerAPI {
 export interface TypeScriptWorkerAPI {
   compileProject(
     files: Array<SampleFile>,
-    importMap: ModuleImportMap,
+    config: {
+      importMap: ModuleImportMap;
+      cdnBaseUrl?: string;
+    },
     emit: (result: BuildOutput) => void
   ): Promise<void>;
 }

--- a/src/test/bare-module-worker_test.ts
+++ b/src/test/bare-module-worker_test.ts
@@ -35,7 +35,7 @@ suite('bare module worker', () => {
     await checkTransform(files, expected, {}, cdn);
   });
 
-  test('one simple import', async () => {
+  test('one simple static import', async () => {
     const files: SampleFile[] = [
       {
         name: 'index.js',
@@ -75,14 +75,15 @@ suite('bare module worker', () => {
     await checkTransform(files, expected, {}, cdn);
   });
 
-  test('multiple simple imports', async () => {
+  test('multiple static and dynamic imports', async () => {
     const files: SampleFile[] = [
       {
         name: 'index.js',
         content: `
            import {a} from "foo/index.js";
-           import {b} from "foo/index.js";
+           const {b} = import("foo/index.js");
            import {c} from "foo/index.js";
+           const {d} = import("foo/index.js");
          `,
       },
     ];
@@ -96,6 +97,7 @@ suite('bare module worker', () => {
                    export const a = 'a';
                    export const b = 'b';
                    export const c = 'c';
+                   export const d = 'd';
                    `,
               },
             },
@@ -110,8 +112,9 @@ suite('bare module worker', () => {
           name: 'index.js',
           content: `
            import {a} from "./node_modules/foo@1.0.0/index.js";
-           import {b} from "./node_modules/foo@1.0.0/index.js";
+           const {b} = import('./node_modules/foo@1.0.0/index.js');
            import {c} from "./node_modules/foo@1.0.0/index.js";
+           const {d} = import('./node_modules/foo@1.0.0/index.js');
          `,
         },
       },
@@ -123,6 +126,7 @@ suite('bare module worker', () => {
                    export const a = 'a';
                    export const b = 'b';
                    export const c = 'c';
+                   export const d = 'd';
                    `,
           contentType: 'text/javascript; charset=utf-8',
         },
@@ -171,7 +175,7 @@ suite('bare module worker', () => {
     await checkTransform(files, expected, {}, cdn);
   });
 
-  test('"module" field is 1st choice for default module', async () => {
+  test('default module uses package.json "module" field as 1st choice', async () => {
     const files: SampleFile[] = [
       {
         name: 'index.js',
@@ -223,7 +227,7 @@ suite('bare module worker', () => {
     await checkTransform(files, expected, {}, cdn);
   });
 
-  test('"main" field is 2nd choice for default module', async () => {
+  test('default module uses package.json "main" field as 2nd choice', async () => {
     const files: SampleFile[] = [
       {
         name: 'index.js',
@@ -274,7 +278,7 @@ suite('bare module worker', () => {
     await checkTransform(files, expected, {}, cdn);
   });
 
-  test('"index.js" is 3rd choice for default module', async () => {
+  test('default module uses "index.js" field as 3rd choice', async () => {
     const files: SampleFile[] = [
       {
         name: 'index.js',

--- a/src/test/bare-module-worker_test.ts
+++ b/src/test/bare-module-worker_test.ts
@@ -4,67 +4,103 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {checkTransform} from './worker-test-util.js';
+
 import type {
   BuildOutput,
   ModuleImportMap,
   SampleFile,
 } from '../shared/worker-api.js';
+import type {CdnData} from './fake-cdn-plugin.js';
 
-import {checkTransform} from './worker-test-util.js';
+const browser = (() => {
+  const ua = navigator.userAgent;
+  if (ua.includes('Chrome')) {
+    return 'chrome';
+  }
+  if (ua.includes('Firefox')) {
+    return 'firefox';
+  }
+  if (ua.includes('Safari')) {
+    return 'safari';
+  }
+  return 'chrome';
+})();
 
-suite('bare module builder', () => {
-  test('transforms static bare module import to unpkg', async () => {
+suite('bare module worker', () => {
+  test('empty project', async () => {
+    const files: SampleFile[] = [];
+    const cdn: CdnData = {};
+    const expected: BuildOutput[] = [];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test('one simple import', async () => {
     const files: SampleFile[] = [
       {
         name: 'index.js',
-        content: 'import "lit-html";',
+        content: 'import "foo/index.js";',
       },
     ];
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'index.js': {
+                content: 'index',
+              },
+            },
+          },
+        },
+      },
+    };
     const expected: BuildOutput[] = [
       {
         kind: 'file',
         file: {
           name: 'index.js',
-          content: 'import "https://unpkg.com/lit-html?module";',
+          content: 'import "./node_modules/foo@1.0.0/index.js";',
         },
       },
-    ];
-    await checkTransform(files, expected);
-  });
-
-  test('transforms dynamic bare module import to unpkg', async () => {
-    const files: SampleFile[] = [
-      {
-        name: 'index.js',
-        content: 'import("lit-html");',
-      },
-    ];
-    const expected: BuildOutput[] = [
       {
         kind: 'file',
         file: {
-          name: 'index.js',
-          content: "import('https://unpkg.com/lit-html?module');",
+          name: 'node_modules/foo@1.0.0/index.js',
+          content: 'index',
+          contentType: 'text/javascript; charset=utf-8',
         },
       },
     ];
-    await checkTransform(files, expected);
+    await checkTransform(files, expected, {}, cdn);
   });
 
-  test('follows import map', async () => {
+  test('multiple simple imports', async () => {
     const files: SampleFile[] = [
       {
         name: 'index.js',
         content: `
-          import "lit-html";
-          import "lit-html/directives/repeat.js";
-        `,
+           import {a} from "foo/index.js";
+           import {b} from "foo/index.js";
+           import {c} from "foo/index.js";
+         `,
       },
     ];
-    const importMap: ModuleImportMap = {
-      imports: {
-        'lit-html': 'https://cdn.skypack.dev/lit-html@2.0.0-pre.7',
-        'lit-html/': 'https://cdn.skypack.dev/lit-html@2.0.0-pre.7/',
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'index.js': {
+                content: `
+                   export const a = 'a';
+                   export const b = 'b';
+                   export const c = 'c';
+                   `,
+              },
+            },
+          },
+        },
       },
     };
     const expected: BuildOutput[] = [
@@ -73,35 +109,645 @@ suite('bare module builder', () => {
         file: {
           name: 'index.js',
           content: `
-          import "https://cdn.skypack.dev/lit-html@2.0.0-pre.7";
-          import "https://cdn.skypack.dev/lit-html@2.0.0-pre.7/directives/repeat.js";
-        `,
+           import {a} from "./node_modules/foo@1.0.0/index.js";
+           import {b} from "./node_modules/foo@1.0.0/index.js";
+           import {c} from "./node_modules/foo@1.0.0/index.js";
+         `,
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/index.js',
+          content: `
+                   export const a = 'a';
+                   export const b = 'b';
+                   export const c = 'c';
+                   `,
+          contentType: 'text/javascript; charset=utf-8',
         },
       },
     ];
-    await checkTransform(files, expected, importMap);
+    await checkTransform(files, expected, {}, cdn);
   });
 
-  test('emits syntax error', async () => {
+  test('namespaced NPM package', async () => {
     const files: SampleFile[] = [
       {
         name: 'index.js',
-        // Note es-module-lexer is very forgiving. It will only throw on syntax
-        // errors around import/export statements.
-        content: 'import"',
+        content: 'import "@foo/bar/index.js";',
       },
     ];
+    const cdn: CdnData = {
+      '@foo/bar': {
+        versions: {
+          '1.0.0': {
+            files: {
+              'index.js': {
+                content: 'index',
+              },
+            },
+          },
+        },
+      },
+    };
     const expected: BuildOutput[] = [
       {
+        kind: 'file',
+        file: {
+          name: 'index.js',
+          content: 'import "./node_modules/@foo/bar@1.0.0/index.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/@foo/bar@1.0.0/index.js',
+          content: 'index',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test('"module" field is 1st choice for default module', async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'index.js',
+        content: 'import "foo";',
+      },
+    ];
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'module.js': {
+                content: 'module',
+              },
+              'main.js': {
+                content: 'main',
+              },
+              'index.js': {
+                content: 'index',
+              },
+              'package.json': {
+                content: `{
+                   "module": "module.js",
+                   "main": "main.js"
+                 }`,
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: BuildOutput[] = [
+      {
+        kind: 'file',
+        file: {
+          name: 'index.js',
+          content: 'import "./node_modules/foo@1.0.0/module.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/module.js',
+          content: 'module',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test('"main" field is 2nd choice for default module', async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'index.js',
+        content: 'import "foo";',
+      },
+    ];
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'module.js': {
+                content: 'module',
+              },
+              'main.js': {
+                content: 'main',
+              },
+              'index.js': {
+                content: 'index',
+              },
+              'package.json': {
+                content: `{
+                   "main": "main.js"
+                 }`,
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: BuildOutput[] = [
+      {
+        kind: 'file',
+        file: {
+          name: 'index.js',
+          content: 'import "./node_modules/foo@1.0.0/main.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/main.js',
+          content: 'main',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test('"index.js" is 3rd choice for default module', async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'index.js',
+        content: 'import "foo";',
+      },
+    ];
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'module.js': {
+                content: 'module',
+              },
+              'main.js': {
+                content: 'main',
+              },
+              'index.js': {
+                content: 'index',
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: BuildOutput[] = [
+      {
+        kind: 'file',
+        file: {
+          name: 'index.js',
+          content: 'import "./node_modules/foo@1.0.0/index.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/index.js',
+          content: 'index',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test('project file in nested directory', async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'some/sub/dir/index.js',
+        content: 'import "foo/index.js";',
+      },
+    ];
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'index.js': {
+                content: 'index',
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: BuildOutput[] = [
+      {
+        kind: 'file',
+        file: {
+          name: 'some/sub/dir/index.js',
+          content: 'import "../../../node_modules/foo@1.0.0/index.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/index.js',
+          content: 'index',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test('import chain in dependency', async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'index.js',
+        content: 'import "foo/a.js";',
+      },
+    ];
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'a.js': {
+                content: 'import "./b.js";',
+              },
+              'b.js': {
+                content: 'import "./c.js";',
+              },
+              'c.js': {
+                content: 'c',
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: BuildOutput[] = [
+      {
+        kind: 'file',
+        file: {
+          name: 'index.js',
+          content: 'import "./node_modules/foo@1.0.0/a.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/a.js',
+          content: 'import "./b.js";',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/b.js',
+          content: 'import "./c.js";',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/c.js',
+          content: 'c',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test('circular import in dependency', async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'index.js',
+        content: 'import "foo/a.js";',
+      },
+    ];
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'a.js': {
+                content: 'import "./b.js";',
+              },
+              'b.js': {
+                content: 'import "./a.js";',
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: BuildOutput[] = [
+      {
+        kind: 'file',
+        file: {
+          name: 'index.js',
+          content: 'import "./node_modules/foo@1.0.0/a.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/a.js',
+          content: 'import "./b.js";',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/b.js',
+          content: 'import "./a.js";',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test("version specified in local project's package.json", async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'index.js',
+        content: 'import "foo/index.js";',
+      },
+      {
+        name: 'package.json',
+        content: `
+           {
+             "dependencies": {
+               "foo": "^2.0.0"
+             }
+           }
+         `,
+      },
+    ];
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'index.js': {
+                content: 'foo1',
+              },
+            },
+          },
+          '2.0.0': {
+            files: {
+              'index.js': {
+                content: 'foo2',
+              },
+            },
+          },
+          '3.0.0': {
+            files: {
+              'index.js': {
+                content: 'foo3',
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: BuildOutput[] = [
+      {
+        kind: 'file',
+        file: {
+          name: 'index.js',
+          content: 'import "./node_modules/foo@2.0.0/index.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@2.0.0/index.js',
+          content: 'foo2',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'package.json',
+          content: `
+           {
+             "dependencies": {
+               "foo": "^2.0.0"
+             }
+           }
+         `,
+        },
+      },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test("version specified in dependency's package.json", async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'index.js',
+        content: 'import "foo/index.js";',
+      },
+    ];
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'index.js': {
+                content: 'import "bar";',
+              },
+              'package.json': {
+                content: `{
+                   "dependencies": {
+                     "bar": "^2.0.0"
+                   }
+                 }`,
+              },
+            },
+          },
+        },
+      },
+      bar: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'index.js': {
+                content: 'bar1',
+              },
+            },
+          },
+          '2.0.0': {
+            files: {
+              'index.js': {
+                content: 'bar2',
+              },
+            },
+          },
+          '3.0.0': {
+            files: {
+              'index.js': {
+                content: 'bar3',
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: BuildOutput[] = [
+      {
+        kind: 'file',
+        file: {
+          name: 'index.js',
+          content: 'import "./node_modules/foo@1.0.0/index.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/index.js',
+          content: 'import "../bar@2.0.0/index.js";',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/bar@2.0.0/index.js',
+          content: 'bar2',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test('extension-less import in project file', async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'index.js',
+        content: 'import "foo/bar";',
+      },
+    ];
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'bar.js': {
+                content: 'bar',
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: BuildOutput[] = [
+      {
+        kind: 'file',
+        file: {
+          name: 'index.js',
+          content: 'import "./node_modules/foo@1.0.0/bar.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/bar.js',
+          contentType: 'text/javascript; charset=utf-8',
+          content: 'bar',
+        },
+      },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test('extension-less import in dependency', async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'index.js',
+        content: 'import "foo/a.js";',
+      },
+    ];
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'a.js': {
+                content: 'import "./b";',
+              },
+              'b.js': {
+                content: 'b',
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: BuildOutput[] = [
+      {
+        kind: 'file',
+        file: {
+          name: 'index.js',
+          content: 'import "./node_modules/foo@1.0.0/a.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/a.js',
+          contentType: 'text/javascript; charset=utf-8',
+          content: 'import "./b.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/b.js',
+          contentType: 'text/javascript; charset=utf-8',
+          content: 'b',
+        },
+      },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test('non-existent dependency', async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'index.js',
+        content: 'import "non-existent/index.js";',
+      },
+    ];
+    const cdn: CdnData = {};
+    const expected: BuildOutput[] = [
+      {
+        kind: 'file',
+        file: {
+          name: 'index.js',
+          content: 'import "non-existent/index.js";',
+        },
+      },
+      {
         diagnostic: {
-          message: 'es-module-lexer error: Parse error @:1:7',
+          message:
+            'Could not resolve module "non-existent/index.js": CDN HTTP 404 error (<CDN-BASE-URL>/non-existent@latest/index.js): Not Found',
           range: {
             end: {
-              character: 7,
+              character: 29,
               line: 0,
             },
             start: {
-              character: 6,
+              character: 8,
               line: 0,
             },
           },
@@ -109,14 +755,121 @@ suite('bare module builder', () => {
         filename: 'index.js',
         kind: 'diagnostic',
       },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test('invalid package.json', async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'index.js',
+        content: 'import "foo/index.js";',
+      },
+      {
+        name: 'package.json',
+        content: `{
+           "dependencies": XXX
+         }`,
+      },
+    ];
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'index.js': {
+                content: 'foo1',
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: BuildOutput[] = [
       {
         kind: 'file',
         file: {
           name: 'index.js',
-          content: 'import"',
+          content: 'import "./node_modules/foo@1.0.0/index.js";',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'node_modules/foo@1.0.0/index.js',
+          content: 'foo1',
+          contentType: 'text/javascript; charset=utf-8',
+        },
+      },
+      {
+        kind: 'file',
+        file: {
+          name: 'package.json',
+          content: `{
+           "dependencies": XXX
+         }`,
+        },
+      },
+      {
+        diagnostic: {
+          message:
+            'Invalid package.json: ' +
+            {
+              chrome: 'SyntaxError: Unexpected token X in JSON at position 29',
+              firefox:
+                'SyntaxError: JSON.parse: unexpected character at line 2 column 28 of the JSON data',
+              safari:
+                'SyntaxError: JSON Parse error: Unexpected identifier "XXX"',
+            }[browser],
+          range: {
+            start:
+              browser === 'safari'
+                ? {line: 0, character: 0}
+                : {line: 1, character: 27},
+            end: {line: 2, character: 10},
+          },
+        },
+        filename: 'package.json',
+        kind: 'diagnostic',
+      },
+    ];
+    await checkTransform(files, expected, {}, cdn);
+  });
+
+  test('use import map', async () => {
+    const files: SampleFile[] = [
+      {
+        name: 'index.js',
+        content: 'import "foo";',
+      },
+    ];
+    const importMap: ModuleImportMap = {
+      imports: {
+        foo: 'http://example.com/foo',
+      },
+    };
+    const cdn: CdnData = {
+      foo: {
+        versions: {
+          '1.0.0': {
+            files: {
+              'index.js': {
+                content: 'foo',
+              },
+            },
+          },
+        },
+      },
+    };
+    const expected: BuildOutput[] = [
+      {
+        kind: 'file',
+        file: {
+          name: 'index.js',
+          content: 'import "http://example.com/foo";',
         },
       },
     ];
-    await checkTransform(files, expected);
+    await checkTransform(files, expected, importMap, cdn);
   });
 });

--- a/src/test/typescript-worker_test.ts
+++ b/src/test/typescript-worker_test.ts
@@ -5,6 +5,7 @@
  */
 
 import type {BuildOutput, SampleFile} from '../shared/worker-api.js';
+import type {CdnData} from './fake-cdn-plugin.js';
 
 import {checkTransform} from './worker-test-util.js';
 
@@ -149,6 +150,19 @@ suite('typescript builder', () => {
         `,
       },
     ];
+    const cdn: CdnData = {
+      'lit-html': {
+        versions: {
+          '1.4.1': {
+            files: {
+              'lit-html.js': {
+                content: '// TODO',
+              },
+            },
+          },
+        },
+      },
+    };
     const expected: BuildOutput[] = [
       {
         diagnostic: {
@@ -175,12 +189,12 @@ suite('typescript builder', () => {
         file: {
           name: 'index.js',
           content:
-            'import { render } from "https://unpkg.com/lit-html?module";\r\n' +
+            'import { render } from "./node_modules/lit-html@1.4.1/index.js";\r\n' +
             'render("hello");\r\n',
           contentType: 'text/javascript',
         },
       },
     ];
-    await checkTransform(files, expected);
+    await checkTransform(files, expected, {}, cdn);
   });
 });

--- a/src/test/worker-test-util.ts
+++ b/src/test/worker-test-util.ts
@@ -37,7 +37,7 @@ export const checkTransform = async (
   importMap: ModuleImportMap = {},
   cdnData: CdnData = {}
 ) => {
-  const {deleteCdnData} = await configureFakeCdn(cdnData);
+  const {cdnBaseUrl, deleteCdnData} = await configureFakeCdn(cdnData);
   try {
     const results: BuildOutput[] = [];
     await new Promise<void>((resolve) => {
@@ -48,7 +48,7 @@ export const checkTransform = async (
           results.push(result);
         }
       };
-      build(files, importMap, emit);
+      build(files, {importMap, cdnBaseUrl}, emit);
     });
 
     assert.deepEqual(

--- a/src/test/worker-test-util.ts
+++ b/src/test/worker-test-util.ts
@@ -51,6 +51,21 @@ export const checkTransform = async (
       build(files, {importMap, cdnBaseUrl}, emit);
     });
 
+    for (const result of results) {
+      if (result.kind === 'diagnostic') {
+        // Sometimes diagnostics contain a CDN URL to help with debugging
+        // (usually the unpkg.com URL). But that will be a local dynamic URL in
+        // testing, so we'll substitute a static string so that we can do a
+        // simple equality test.
+        while (result.diagnostic.message.includes(cdnBaseUrl)) {
+          result.diagnostic.message = result.diagnostic.message.replace(
+            cdnBaseUrl,
+            '<CDN-BASE-URL>/'
+          );
+        }
+      }
+    }
+
     assert.deepEqual(
       results.sort(sortBuildOutput),
       expected.sort(sortBuildOutput)

--- a/src/typescript-worker/bare-module-transformer.ts
+++ b/src/typescript-worker/bare-module-transformer.ts
@@ -62,9 +62,8 @@ export class BareModuleTransformer {
   async *process(
     results: AsyncIterable<BuildOutput> | Iterable<BuildOutput>
   ): AsyncIterable<BuildOutput> {
-    // We're going to asynchronously walk the entire dependency graph. This
-    // "output" object helps us merge the output of each dependency module into
-    // a single combined output async iterator.
+    // This "output" iterable helps us emit all build outputs as soon as they
+    // are available as we asynchronously walk the dependency tree.
     const output = new MergedAsyncIterables<BuildOutput>();
     output.add(this._handleProjectFiles(results, output));
     yield* output;

--- a/src/typescript-worker/bare-module-transformer.ts
+++ b/src/typescript-worker/bare-module-transformer.ts
@@ -5,35 +5,115 @@
  */
 
 import * as esModuleLexer from 'es-module-lexer';
-import {ModuleResolver} from './module-resolver.js';
+import {
+  MergedAsyncIterables,
+  parseNpmStyleSpecifier,
+  resolveUrlPath,
+  charToLineAndChar,
+  fileExtension,
+  isExactSemverVersion,
+  classifySpecifier,
+  relativeUrlPath,
+} from './util.js';
+import {Deferred} from '../shared/deferred.js';
 
 import type {
   BuildOutput,
   DiagnosticBuildOutput,
   FileBuildOutput,
+  SampleFile,
 } from '../shared/worker-api.js';
+import type {ModuleResolver} from './module-resolver.js';
+import type {CachingCdn} from './caching-cdn.js';
+import type {NpmFileLocation, PackageJson} from './util.js';
 
+/**
+ * Transforms bare module specifiers in .js files to canonical local paths, and
+ * adds the corresponding modules to the virtual filesystem.
+ *
+ * For example, transforms:
+ *   import {html} from "lit";
+ * Into:
+ *   import {html} from "./node_modules/lit@2.1.2/index.js";
+ *
+ * Dependencies are served from within the local
+ * "<service-worker-scope>/node_modules/" path. This allows us to transform not
+ * only our own project files, but the entire module dependency graph too.
+ *
+ * Specifiers are canonicalized to include the latest concrete version that is
+ * compatible with the semver range, and to make default modules and file
+ * extensions explicit. This provides improved module de-duplication over
+ * unpkg.com's "?module" mode, which does not canonicalize.
+ *
+ * Version constraints are read from the "dependencies" field of package.json
+ * files, both in dependencies and in the top-level project itself. If the
+ * project doesn't contain a package.json file, the latest versions are assumed.
+ */
 export class BareModuleTransformer {
-  private _moduleResolver: ModuleResolver;
+  private _cdn: CachingCdn;
+  private _importMapResolver: ModuleResolver;
+  private _emittedExternalDependencies = new Set<string>();
 
-  constructor(moduleResolver: ModuleResolver) {
-    this._moduleResolver = moduleResolver;
+  constructor(cdn: CachingCdn, importMapResolver: ModuleResolver) {
+    this._cdn = cdn;
+    this._importMapResolver = importMapResolver;
   }
 
   async *process(
     results: AsyncIterable<BuildOutput> | Iterable<BuildOutput>
   ): AsyncIterable<BuildOutput> {
+    // We're going to asynchronously walk the entire dependency graph. This
+    // "output" object helps us merge the output of each dependency module into
+    // a single combined output async iterator.
+    const output = new MergedAsyncIterables<BuildOutput>();
+    output.add(this._handleProjectFiles(results, output));
+    yield* output;
+  }
+
+  /**
+   * Handle files from the top-level project.
+   */
+  private async *_handleProjectFiles(
+    results: AsyncIterable<BuildOutput> | Iterable<BuildOutput>,
+    output: MergedAsyncIterables<BuildOutput>
+  ): AsyncIterable<BuildOutput> {
+    // The project might contain a package.json, which will determine our
+    // top-level version constraints. Resolve it lazily.
+    const packageJson = new Deferred<PackageJson | undefined>();
+    const getPackageJson = () => packageJson.promise;
     for await (const result of results) {
       if (result.kind === 'file' && result.file.name.endsWith('.js')) {
-        yield* this._transformBareModuleSpecifiers(result);
+        output.add(this._handleModule(result, getPackageJson, output));
       } else {
         yield result;
+        if (result.kind === 'file' && result.file.name === 'package.json') {
+          let parsed: PackageJson | undefined;
+          try {
+            parsed = JSON.parse(result.file.content) as PackageJson;
+          } catch (e) {
+            yield makeJsonParseDiagnostic(e, result.file);
+          }
+          if (parsed !== undefined) {
+            packageJson.resolve(parsed);
+          }
+        }
       }
+    }
+    if (!packageJson.settled) {
+      // We never found a package.json.
+      packageJson.resolve(undefined);
     }
   }
 
-  private async *_transformBareModuleSpecifiers(
-    file: FileBuildOutput
+  /**
+   * Transform all of the imported module specifiers in the given JS module,
+   * emit the transformed file, and process any dependencies corresponding to
+   * those specifiers.
+   */
+  private async *_handleModule(
+    file: FileBuildOutput,
+    getPackageJson: () => Promise<PackageJson | undefined>,
+    output: MergedAsyncIterables<BuildOutput>
   ): AsyncIterable<BuildOutput> {
     let js = file.file.content;
     let specifiers;
@@ -42,31 +122,61 @@ export class BareModuleTransformer {
       [specifiers] = esModuleLexer.parse(js);
     } catch (e) {
       yield file;
-      const diagnostic = this._makeDiagnostic(e, file.file.name);
+      const diagnostic = makeEsModuleLexerDiagnostic(e, file.file.name);
       if (diagnostic !== undefined) {
         yield diagnostic;
       }
       return;
     }
-
+    const transforms = [];
+    // Note we iterating backwards so that the character offsets are not
+    // invalidated after each substitution.
     for (let i = specifiers.length - 1; i >= 0; i--) {
-      const {
-        s: start,
-        e: end,
-        n: oldSpecifier,
-        d: dynamicStart,
-      } = specifiers[i];
+      const {n: oldSpecifier} = specifiers[i];
       if (oldSpecifier === undefined) {
         // E.g. A dynamic import that's not a static string, like
         // `import(someVariable)`. We can't handle this, skip.
         continue;
       }
-      const newSpecifier = this._transformSpecifier(oldSpecifier);
+      transforms.push({
+        info: specifiers[i],
+        newSpecifierPromise: this._handleSpecifier(
+          oldSpecifier,
+          file.file.name,
+          getPackageJson,
+          output
+        ),
+      });
+    }
+    for (const {
+      info: {s: start, e: end, n: oldSpecifier, d: dynamicStart},
+      newSpecifierPromise,
+    } of transforms) {
+      let newSpecifier;
+      try {
+        newSpecifier = await newSpecifierPromise;
+      } catch (e) {
+        // TODO(aomarks) If this was a TypeScript file, the user isn't going to
+        // see this diagnostic, since we're looking at the JS file. To show it
+        // correctly on the original file, we'll need source maps support.
+        yield {
+          kind: 'diagnostic',
+          filename: file.file.name,
+          diagnostic: {
+            message: `Could not resolve module "${oldSpecifier}": ${e.message}`,
+            range: {
+              start: charToLineAndChar(js, start),
+              end: charToLineAndChar(js, end),
+            },
+          },
+        };
+        continue;
+      }
       if (newSpecifier === oldSpecifier) {
         continue;
       }
-      const isDynamic = dynamicStart !== -1;
       // For dynamic imports, the start/end range doesn't include quotes.
+      const isDynamic = dynamicStart !== -1;
       const replacement = isDynamic ? `'${newSpecifier}'` : newSpecifier;
       js = js.substring(0, start) + replacement + js.substring(end);
     }
@@ -74,31 +184,231 @@ export class BareModuleTransformer {
     yield file;
   }
 
-  private _transformSpecifier(specifier: string): string {
-    const {type, url} = this._moduleResolver.resolve(specifier, self.origin);
-    return type === 'bare' ? url : specifier;
+  /**
+   * Transform the given module specifier and process the dependency
+   * corresponding to it if needed.
+   */
+  private async _handleSpecifier(
+    specifier: string,
+    referrer: string,
+    getPackageJson: () => Promise<PackageJson | undefined>,
+    output: MergedAsyncIterables<BuildOutput>
+  ): Promise<string> {
+    const fromImportMap =
+      this._importMapResolver.resolveUsingImportMap(specifier);
+    if (fromImportMap !== null) {
+      return fromImportMap;
+    }
+    const kind = classifySpecifier(specifier);
+    if (kind === 'url') {
+      return specifier;
+    }
+    if (kind === 'bare') {
+      return this._handleBareSpecifier(
+        specifier,
+        referrer,
+        getPackageJson,
+        output
+      );
+    }
+    // Anything else is a relative specifier.
+    if (!referrer.startsWith('node_modules/')) {
+      // A relative specifier within a top-level project file. This specifier
+      // must resolve to another top-level project file, so there's nothing more
+      // we need to do here.
+      return specifier;
+    }
+    // E.g. if `referrer` is "node_modules/foo@1.2.3/a.js" and `specifier` is
+    // "./b.js", then `absolute` will be "node_modules/foo@1.2.3/b.js", and
+    // `bare` will be "foo@1.2.3/b.js".
+    const absolute = resolveUrlPath(referrer, specifier);
+    const bare = absolute.slice('/node_modules/'.length);
+    if (!fileExtension(specifier)) {
+      // We can't simply return the existing relative specifier if there's no
+      // ".js" extension, because we still need to do path canonicalization. For
+      // example: "./foo" could refer to "./foo.js" or "./foo/index.js"
+      // depending on what files are published to this package. We need to
+      // consult the CDN to figure that out.
+      return this._handleBareSpecifier(
+        bare,
+        referrer,
+        // Note we never need a package.json here, because the version is
+        // already included in the specifier itself at this point. We also
+        // wouldn't want to pass this scope's `getPackageJson`, because it would
+        // be the wrong one.
+        async () => undefined,
+        output
+      );
+    }
+    // This relative specifier is good as-is, since it has an extension. We just
+    // need to fetch it.
+    const parsed = parseNpmStyleSpecifier(bare);
+    if (parsed === undefined) {
+      throw new Error(`Invalid specifier "${bare}"`);
+    }
+    output.add(this._fetchExternalDependency(parsed, output));
+    return specifier;
   }
 
-  private _makeDiagnostic(
-    e: Error,
-    filename: string
-  ): DiagnosticBuildOutput | undefined {
-    const match = e.message.match(/@:(\d+):(\d+)$/);
-    if (match === null) {
-      return undefined;
+  /**
+   * Canonicalize the given bare module specifier, then fetch it and add it to
+   * the local filesystem.
+   */
+  private async _handleBareSpecifier(
+    specifier: string,
+    referrer: string,
+    getPackageJson: () => Promise<PackageJson | undefined>,
+    output: MergedAsyncIterables<BuildOutput>
+  ): Promise<string> {
+    let location = parseNpmStyleSpecifier(specifier);
+    if (location === undefined) {
+      throw new Error(`Invalid specifier "${specifier}"`);
     }
-    const line = Number(match[1]) - 1;
-    const character = Number(match[2]) - 1;
-    return {
-      kind: 'diagnostic',
-      filename,
-      diagnostic: {
-        message: `es-module-lexer error: ${e.message}`,
-        range: {
-          start: {line, character},
-          end: {line, character: character + 1},
+    if (!location.version) {
+      location.version =
+        (await getPackageJson())?.dependencies?.[location.pkg] ?? 'latest';
+    }
+    if (location.path === '') {
+      const packageJson = await this._cdn.fetchPackageJson(location);
+      location.path = packageJson.module ?? packageJson.main ?? 'index.js';
+    }
+    if (
+      !fileExtension(location.path) ||
+      !isExactSemverVersion(location.version)
+    ) {
+      location = await this._cdn.canonicalize(location);
+    }
+    output.add(this._fetchExternalDependency(location, output));
+    const absolute = `node_modules/${location.pkg}@${location.version}/${location.path}`;
+    const relative = relativeUrlPath(referrer, absolute);
+    return relative;
+  }
+
+  /**
+   * Fetch the given external module, and add it to the local filesystem under
+   * its "node_modules/" path.
+   */
+  private async *_fetchExternalDependency(
+    location: NpmFileLocation,
+    output: MergedAsyncIterables<BuildOutput>
+  ) {
+    const path = `${location.pkg}@${location.version}/${location.path}`;
+    if (this._emittedExternalDependencies.has(path)) {
+      // We already emitted this dependency. Avoid import loops and wasteful
+      // double fetches.
+      return;
+    }
+    this._emittedExternalDependencies.add(path);
+    let asset;
+    try {
+      asset = await this._cdn.fetch(location);
+    } catch (e) {
+      // TODO(aomarks) This file will end up as a 404 error when fetched from
+      // the preview iframe, because we're simply omitting this file from our
+      // output on error. We should instead allow FileBuildOutput to carry an
+      // HTTP status code, so then we could propagate this specific error to be
+      // served by the service worker, so that it shows up more usefully in the
+      // network tab.
+      console.error(`Error fetching ${path} from CDN: ${e.message}`);
+      return;
+    }
+    let packageJson: PackageJson | undefined | null = null;
+    const getPackageJson = async (): Promise<PackageJson | undefined> => {
+      if (packageJson === null) {
+        try {
+          packageJson = await this._cdn.fetchPackageJson(location);
+        } catch {
+          packageJson = undefined;
+        }
+      }
+      return packageJson;
+    };
+    yield* this._handleModule(
+      {
+        kind: 'file',
+        file: {
+          name: `node_modules/${path}`,
+          content: asset.content,
+          contentType: asset.contentType,
         },
       },
-    };
+      getPackageJson,
+      output
+    );
   }
 }
+
+/**
+ * Create a useful Playground diagnostic from an es-module-lexer exception.
+ */
+const makeEsModuleLexerDiagnostic = (
+  e: Error,
+  filename: string
+): DiagnosticBuildOutput | undefined => {
+  const match = e.message.match(/@:(\d+):(\d+)$/);
+  if (match === null) {
+    return undefined;
+  }
+  const line = Number(match[1]) - 1;
+  const character = Number(match[2]) - 1;
+  return {
+    kind: 'diagnostic',
+    filename,
+    diagnostic: {
+      message: `es-module-lexer error: ${e.message}`,
+      range: {
+        start: {line, character},
+        end: {line, character: character + 1},
+      },
+    },
+  };
+};
+
+/**
+ * Create a useful Playground diagnostic from a JSON.parse exception.
+ */
+const makeJsonParseDiagnostic = (
+  e: Error,
+  file: SampleFile
+): DiagnosticBuildOutput => {
+  const start = extractPositionFromJsonParseError(e.message, file.content) ?? {
+    line: 0,
+    character: 0,
+  };
+  return {
+    kind: 'diagnostic',
+    filename: file.name,
+    diagnostic: {
+      message: `Invalid package.json: ${e}`,
+      range: {
+        start,
+        // To the rest of the file.
+        end: charToLineAndChar(file.content, file.content.length),
+      },
+    },
+  };
+};
+
+/**
+ * Try to extract the line and character from a `JSON.parse` exception message.
+ *
+ * Chrome and Firefox often include this information, but using different
+ * formats. Safari never includes this information.
+ */
+const extractPositionFromJsonParseError = (
+  message: string,
+  json: string
+): {line: number; character: number} | undefined => {
+  const chrome = message.match(/at position (\d+)/);
+  if (chrome !== null) {
+    return charToLineAndChar(json, Number(chrome[1]));
+  }
+  const firefox = message.match(/at line (\d+) column (\d+)/);
+  if (firefox !== null) {
+    return {
+      line: Number(firefox[1]) - 1,
+      character: Number(firefox[2]) - 1,
+    };
+  }
+  return undefined;
+};

--- a/src/typescript-worker/build.ts
+++ b/src/typescript-worker/build.ts
@@ -16,7 +16,10 @@ import type {
 
 export const build = async (
   files: Array<SampleFile>,
-  importMap: ModuleImportMap,
+  config: {
+    importMap: ModuleImportMap;
+    cdnBaseUrl?: string;
+  },
   emit: (result: BuildOutput) => void
 ): Promise<void> => {
   const moduleResolver = new ModuleResolver(importMap);

--- a/src/typescript-worker/build.ts
+++ b/src/typescript-worker/build.ts
@@ -13,6 +13,7 @@ import type {
   ModuleImportMap,
   BuildOutput,
 } from '../shared/worker-api.js';
+import {CachingCdn} from './caching-cdn.js';
 
 export const build = async (
   files: Array<SampleFile>,
@@ -22,9 +23,10 @@ export const build = async (
   },
   emit: (result: BuildOutput) => void
 ): Promise<void> => {
-  const moduleResolver = new ModuleResolver(importMap);
+  const moduleResolver = new ModuleResolver(config.importMap);
+  const cdn = new CachingCdn(config.cdnBaseUrl ?? 'https://unpkg.com/');
   const tsBuilder = new TypeScriptBuilder(moduleResolver);
-  const bareModuleBuilder = new BareModuleTransformer(moduleResolver);
+  const bareModuleBuilder = new BareModuleTransformer(cdn, moduleResolver);
   const results = bareModuleBuilder.process(
     tsBuilder.process(files.map((file) => ({kind: 'file', file})))
   );

--- a/src/typescript-worker/module-resolver.ts
+++ b/src/typescript-worker/module-resolver.ts
@@ -23,6 +23,9 @@ export class ModuleResolver {
     this.importMap = importMap;
   }
 
+  // TODO(aomarks) Remove this method and rename this class to ImportMapResolver
+  // once TypeFetcher has been updated to the new dependency handling approach
+  // that won't need this method.
   resolve(specifier: string, referrer: string | URL): ResolvedSpecifier {
     const importMapUrl = this.resolveUsingImportMap(specifier);
     if (importMapUrl !== null) {

--- a/src/typescript-worker/module-resolver.ts
+++ b/src/typescript-worker/module-resolver.ts
@@ -24,7 +24,7 @@ export class ModuleResolver {
   }
 
   resolve(specifier: string, referrer: string | URL): ResolvedSpecifier {
-    const importMapUrl = this._resolveUsingImportMap(specifier);
+    const importMapUrl = this.resolveUsingImportMap(specifier);
     if (importMapUrl !== null) {
       return {type: 'bare' as const, url: importMapUrl};
     }
@@ -47,7 +47,7 @@ export class ModuleResolver {
     }
   }
 
-  private _resolveUsingImportMap(specifier: string): string | null {
+  resolveUsingImportMap(specifier: string): string | null {
     // For overview, see https://github.com/WICG/import-maps
     // For algorithm, see https://wicg.github.io/import-maps/#resolving
     // TODO(aomarks) Add support for `scopes`.


### PR DESCRIPTION
A major refactor to the way external dependencies are handled in Playground.

**Note to reviewer**: I recommend looking at each commit separately.

## Background

Before this PR, Playground directly transforms bare module specifiers to `https://unpkg.com/...?module` URLs. This works well for simple cases, but quickly breaks down because of issues around *module duplication*.

When the browser imports a module with some specifier, it caches that module *using exactly the given specifier as the key*. It doesn't matter if the URL ends up redirecting elsewhere -- that *original* specifier remains the key that determines the identity of the module. So, if another import statement imports what is ultimately the same module, but using a specifier that is different in any way, the browser will end up loading the same module *twice*. This is particularly problematic for custom element libraries, since registering an element with the same name twice throws an exception.

The following specifiers all represent the same underlying module, and will ultimately redirect to the same URL. But the browser will treat all of these specifiers as separate modules. *All of this variation can and does currently occur when using playground*, because import specifiers are not canonicalized -- neither in project files by us, nor in dependencies by unpkg:

```ts
/// What we transform `import 'foo';` to:
import 'https://unpkg.com/foo?module';

// What is ultimately redirected to:
import 'https://unpkg.com/foo@1.2.3/index.js?module';

// What another dependency's import of the same module might look like:
import 'https://unpkg.com/foo@^1.0.0?module';

// ... or this (a different, but compatible semver range):
import 'https://unpkg.com/foo@^1.2.0?module';

// ... or this (the default module is explicit, instead of implicit):
import 'https://unpkg.com/foo@^1.0.0/index.js?module';
```


### Real example 1: importing `<paper-input>`

[This](https://lit.dev/playground/#project=W3sibmFtZSI6ImluZGV4LnRzIiwiY29udGVudCI6ImltcG9ydCAnQHBvbHltZXIvcGFwZXItaW5wdXQvcGFwZXItaW5wdXQuanMnOyJ9LHsibmFtZSI6ImluZGV4Lmh0bWwiLCJjb250ZW50IjoiPHNjcmlwdCB0eXBlPVwibW9kdWxlXCIgc3JjPVwiLi9pbmRleC5qc1wiPjwvc2NyaXB0PlxuPHBhcGVyLWlucHV0IGxhYmVsPVwiRm9vXCI-PC9wYXBlci1pbnB1dD4ifV0) simple example of importing and using `<paper-input>` currently fails because:

1. `https://unpkg.com/@polymer/paper-input@3.2.1/paper-input.js?module` contains the import specifier `https://unpkg.com/@polymer/polymer@^3.0.0/lib/elements/dom-module.js?module`. Note the `@^3.0.0` in the specifier: unpkg simply substitutes the semver range from the `package.json` directly into the specifier, instead of resolving it to a concrete version first.
2. Via another import, `https://unpkg.com/@polymer/paper-input@3.2.1/paper-input.js?module`  imports `https://unpkg.com/@polymer/polymer@3.4.1/lib/mixins/element-mixin.js?module`.
3. `https://unpkg.com/@polymer/polymer@3.4.1/lib/mixins/element-mixin.js?module` imports `../elements/dom-module.js?module` aka `https://unpkg.com/@polymer/polymer@3.4.1/lib/elements/dom-module.js?module`.
4. An `Uncaught DOMException: Failed to execute 'define' on 'CustomElementRegistry': the name "dom-module" has already been used with this registry` exception is thrown, because `dom-module.js` was loaded twice, using two different specifiers, which resulted in a double registration of the `<dom-module>` element.

### Real example 2: localization global state

The localization example: https://lit.dev/docs/libraries/localization/#example (filed at https://github.com/lit/lit.dev/issues/395) currently fails because:

1. The project file imports `@lit/localize`, which is transformed to `https://unpkg.com/@lit/localize`, and redirected to `https://unpkg.com/@lit/localize@0.10.3/lit-localize.js`.
2. `https://unpkg.com/@lit/localize@0.10.3/lit-localize.js` imports `./init/runtime.js`
3. `https://unpkg.com/@lit/localize@0.10.3/init/runtime.js` imports `../lit-localize.js` (yes, a circular import -- but that's valid in JS modules), and calls a function that modifies some module-scoped state in `lit-localize.js`
4. The module whose state was modified in 3 *is a different module* versus the one that we imported in 1 according to the browser, because while the two redirect to the same URL, their initial import specifier was different. This causes the example to fail.

## Changes

1. Module specifiers are now transformed to a path under `<service-worker-scope>/node_modules/`, instead of directly to unpkg URLs. This way, all dependency modules fall under the purview of our service worker, allowing us to provide those files ourselves.

2. Dependency modules are now parsed and transformed by us. We no longer use the unpkg `?module` mode. This allows us to implement more thorough canonicalization, and also lets us apply import maps to dependencies. Fixes https://github.com/PolymerLabs/playground-elements/issues/104.

3. Module specifiers are now always fully canonicalized. Versions are always resolved to their latest, concrete version (e.g. `^1.0.0` and `^1.1.0` are both canonicalized to `1.2.3`), and the default module is always made explicit (e.g. `foo` is canonicalized to `foo/index.js`). This is true both for imports in project files, and transitively within the entire dependency graph. Fixes https://github.com/PolymerLabs/playground-elements/issues/182.

4. We now check for a `package.json` in the project files, and use it for version constraints, just like how local NPM works. Previously, changing versions could only be done with an import map. The new approach should be more intuitive. It also means that when you click the "Download" button to get a tarball when a `package.json` is present, you'll get a configuration with correct versions locally too! Fixes https://github.com/PolymerLabs/playground-elements/issues/183.

## TODO

There will be a couple of follow-up PRs after this one:

1. Updating the `TypesFetcher` to follow the same logic. Currently, TypeScript type files are still fetched using the old approach, so the two are not in sync. I'll make sure to send this PR before the next release. (https://github.com/PolymerLabs/playground-elements/issues/184)

2. Add some caching. Since we now have to parse our dependency modules ourselves, there's a bit of a slowdown. However, a dependency at a given version never changes, so we can add some aggressive caching, meaning each dependency only needs to be parsed once per playground session + version. (https://github.com/PolymerLabs/playground-elements/issues/185)