### PR TITLE
Update CHANGELOG for 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   fetched from unpkg, but they are now themselves transformed to ensure correct
   specifier canonicalization.
 
+## [0.11.1] - 2021-08-09
+
+- Added MIME-type detection for the following project file extensions: `gif`,
+  `ico`, `jpeg`, `jpg`, `mid`, `midi`, `mp3`, `png`, `svg`, `weba`, `webm`,
+  `webp`.
+
 ## [0.11.0] - 2021-07-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "playground-elements",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@material/mwc-button": "^0.22.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playground-elements",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A multi-file code editor component with live preview",
   "homepage": "https://github.com/PolymerLabs/playground-elements#readme",
   "repository": "github:PolymerLabs/playground-elements",


### PR DESCRIPTION
This release will actually be done off a different commit, since the latest changes to dependency resolution are not yet ready for release.