### PR TITLE
Add NodeModulesLayoutMaker class

### DIFF
--- a/src/test/node-modules-layout-maker_test.ts
+++ b/src/test/node-modules-layout-maker_test.ts
@@ -1,0 +1,303 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {assert} from '@esm-bundle/chai';
+import {
+  NodeModulesLayoutMaker,
+  DependencyGraph,
+  NodeModulesDirectory,
+  PackageDependencies,
+} from '../typescript-worker/node-modules-layout-maker.js';
+
+suite('NodeModulesLayoutMaker', () => {
+  const checkLayout = (
+    rootDeps: PackageDependencies,
+    depGraph: DependencyGraph,
+    expected: NodeModulesDirectory
+  ) => {
+    const layouter = new NodeModulesLayoutMaker();
+    const actual = layouter.layout(rootDeps, depGraph);
+    assert.deepEqual(actual, expected);
+  };
+
+  test('no dependencies', async () => {
+    // ROOT
+    const rootDeps: PackageDependencies = {};
+    const depGraph: DependencyGraph = {};
+    const expected: NodeModulesDirectory = {};
+    checkLayout(rootDeps, depGraph, expected);
+  });
+
+  test('only direct dependencies', async () => {
+    //    ROOT
+    //     /\
+    //    /  \
+    //   v    v
+    //  A1    B2
+    const rootDeps: PackageDependencies = {
+      a: '1',
+      b: '2',
+    };
+    const depGraph: DependencyGraph = {};
+    // ROOT
+    // ├── A1
+    // └── B2
+    const expected: NodeModulesDirectory = {
+      a: {version: '1', nodeModules: {}},
+      b: {version: '2', nodeModules: {}},
+    };
+    checkLayout(rootDeps, depGraph, expected);
+  });
+
+  test('simple chain', async () => {
+    //  ROOT
+    //    |
+    //    v
+    //    A1
+    //    |
+    //    v
+    //    B2
+    //    |
+    //    v
+    //    C3
+    const rootDeps: PackageDependencies = {
+      a: '1',
+    };
+    const depGraph: DependencyGraph = {
+      a: {1: {b: '2'}},
+      b: {2: {c: '3'}},
+    };
+    // ROOT
+    // ├── A1
+    // ├── B2
+    // └── C3
+    const expected: NodeModulesDirectory = {
+      a: {version: '1', nodeModules: {}},
+      b: {version: '2', nodeModules: {}},
+      c: {version: '3', nodeModules: {}},
+    };
+    checkLayout(rootDeps, depGraph, expected);
+  });
+
+  test('version conflict between root and branch', async () => {
+    //   ROOT
+    //    /\
+    //   v  v
+    //  A1  B1
+    //   |
+    //   v
+    //   B2
+    const rootDeps: PackageDependencies = {
+      a: '1',
+      b: '1',
+    };
+    const depGraph: DependencyGraph = {
+      a: {1: {b: '2'}},
+    };
+    // ROOT
+    // ├── A1
+    // │   └── B2
+    // └── B1
+    const expected: NodeModulesDirectory = {
+      a: {
+        version: '1',
+        nodeModules: {
+          b: {version: '2', nodeModules: {}},
+        },
+      },
+      b: {version: '1', nodeModules: {}},
+    };
+    checkLayout(rootDeps, depGraph, expected);
+  });
+
+  test('version conflict between root and longer branch', async () => {
+    //       ROOT
+    //        /\
+    //       /  \
+    //      v    v
+    //     A1    B1
+    //      |
+    //      v
+    //     C1
+    //      |
+    //      v
+    //     B2
+    const rootDeps: PackageDependencies = {
+      a: '1',
+      b: '1',
+    };
+    const depGraph: DependencyGraph = {
+      a: {1: {c: '1'}},
+      c: {1: {b: '2'}},
+    };
+    // ROOT
+    // ├── A1
+    // ├── B1
+    // └── C1
+    //     └── B2
+    const expected: NodeModulesDirectory = {
+      a: {version: '1', nodeModules: {}},
+      b: {version: '1', nodeModules: {}},
+      c: {
+        version: '1',
+        nodeModules: {
+          b: {
+            version: '2',
+            nodeModules: {},
+          },
+        },
+      },
+    };
+    checkLayout(rootDeps, depGraph, expected);
+  });
+
+  test('version conflict between two branches', async () => {
+    //     ROOT
+    //      /\
+    //     /  \
+    //    v    v
+    //   A1    B1
+    //   |      |
+    //   v      v
+    //  C1      C2
+    const rootDeps: PackageDependencies = {
+      a: '1',
+      b: '1',
+    };
+    const depGraph: DependencyGraph = {
+      a: {1: {c: '1'}},
+      b: {1: {c: '2'}},
+    };
+    // ROOT
+    // ├── A1
+    // ├── B1
+    // │   └── C2
+    // └── C1
+    const expected: NodeModulesDirectory = {
+      a: {version: '1', nodeModules: {}},
+      b: {
+        version: '1',
+        nodeModules: {
+          c: {version: '2', nodeModules: {}},
+        },
+      },
+      c: {version: '1', nodeModules: {}},
+    };
+    checkLayout(rootDeps, depGraph, expected);
+  });
+
+  test('version conflict requiring directory duplication', async () => {
+    //      ROOT
+    //       /|\
+    //      / | \
+    //     /  |  \
+    //    v   v   v
+    //    A1  B1  C1
+    //         \   /
+    //          \ /
+    //           v
+    //           A2 --> D1
+    const rootDeps: PackageDependencies = {
+      a: '1',
+      b: '1',
+      c: '1',
+    };
+    const depGraph: DependencyGraph = {
+      a: {2: {d: '1'}},
+      b: {1: {a: '2'}},
+      c: {1: {a: '2'}},
+    };
+    // ROOT
+    // ├── A1
+    // ├── B1
+    // │   └── A2
+    // ├── C1
+    // │   └── A2
+    // └── D1
+    const expected: NodeModulesDirectory = {
+      a: {
+        version: '1',
+        nodeModules: {},
+      },
+      b: {
+        version: '1',
+        nodeModules: {
+          a: {version: '2', nodeModules: {}},
+        },
+      },
+      c: {
+        version: '1',
+        nodeModules: {
+          a: {version: '2', nodeModules: {}},
+        },
+      },
+      d: {
+        version: '1',
+        nodeModules: {},
+      },
+    };
+    checkLayout(rootDeps, depGraph, expected);
+  });
+
+  test('short loop', async () => {
+    //   ROOT --> A1 --> B1
+    //             ^     |
+    //             |     |
+    //             +-----+
+    const rootDeps: PackageDependencies = {
+      a: '1',
+    };
+    const depGraph: DependencyGraph = {
+      a: {1: {b: '1'}},
+      b: {1: {a: '1'}},
+    };
+    // ROOT
+    // ├── A1
+    // └── B1
+    const expected: NodeModulesDirectory = {
+      a: {version: '1', nodeModules: {}},
+      b: {version: '1', nodeModules: {}},
+    };
+    checkLayout(rootDeps, depGraph, expected);
+  });
+
+  test('longer loop on a branch', async () => {
+    //       ROOT
+    //        /\
+    //       /  \
+    //      v    v
+    //     A1    C1
+    //    /  ^
+    //   /    \
+    //  v      \
+    //  B1 --> C2
+    const rootDeps: PackageDependencies = {
+      a: '1',
+      c: '1',
+    };
+    const depGraph: DependencyGraph = {
+      a: {1: {b: '1'}},
+      b: {1: {c: '2'}},
+      c: {2: {a: '1'}},
+    };
+    // ROOT
+    // ├── A1
+    // ├── C1
+    // └── B1
+    //     └── C2
+    const expected: NodeModulesDirectory = {
+      a: {version: '1', nodeModules: {}},
+      c: {version: '1', nodeModules: {}},
+      b: {
+        version: '1',
+        nodeModules: {
+          c: {version: '2', nodeModules: {}},
+        },
+      },
+    };
+    checkLayout(rootDeps, depGraph, expected);
+  });
+});

--- a/src/test/node-modules-layout-maker_test.ts
+++ b/src/test/node-modules-layout-maker_test.ts
@@ -18,8 +18,8 @@ suite('NodeModulesLayoutMaker', () => {
     depGraph: DependencyGraph,
     expected: NodeModulesDirectory
   ) => {
-    const layouter = new NodeModulesLayoutMaker();
-    const actual = layouter.layout(rootDeps, depGraph);
+    const layoutMaker = new NodeModulesLayoutMaker();
+    const actual = layoutMaker.layout(rootDeps, depGraph);
     assert.deepEqual(actual, expected);
   };
 

--- a/src/test/node-modules-layout-maker_test.ts
+++ b/src/test/node-modules-layout-maker_test.ts
@@ -23,7 +23,7 @@ suite('NodeModulesLayoutMaker', () => {
     assert.deepEqual(actual, expected);
   };
 
-  test('no dependencies', async () => {
+  test('no dependencies', () => {
     // ROOT
     const rootDeps: PackageDependencies = {};
     const depGraph: DependencyGraph = {};
@@ -31,7 +31,7 @@ suite('NodeModulesLayoutMaker', () => {
     checkLayout(rootDeps, depGraph, expected);
   });
 
-  test('only direct dependencies', async () => {
+  test('only direct dependencies', () => {
     //    ROOT
     //     /\
     //    /  \
@@ -52,7 +52,7 @@ suite('NodeModulesLayoutMaker', () => {
     checkLayout(rootDeps, depGraph, expected);
   });
 
-  test('simple chain', async () => {
+  test('simple chain', () => {
     //  ROOT
     //    |
     //    v
@@ -82,7 +82,7 @@ suite('NodeModulesLayoutMaker', () => {
     checkLayout(rootDeps, depGraph, expected);
   });
 
-  test('version conflict between root and branch', async () => {
+  test('version conflict between root and branch', () => {
     //   ROOT
     //    /\
     //   v  v
@@ -113,7 +113,7 @@ suite('NodeModulesLayoutMaker', () => {
     checkLayout(rootDeps, depGraph, expected);
   });
 
-  test('version conflict between root and longer branch', async () => {
+  test('version conflict between root and longer branch', () => {
     //       ROOT
     //        /\
     //       /  \
@@ -154,7 +154,7 @@ suite('NodeModulesLayoutMaker', () => {
     checkLayout(rootDeps, depGraph, expected);
   });
 
-  test('version conflict between two branches', async () => {
+  test('version conflict between two branches', () => {
     //     ROOT
     //      /\
     //     /  \
@@ -189,7 +189,7 @@ suite('NodeModulesLayoutMaker', () => {
     checkLayout(rootDeps, depGraph, expected);
   });
 
-  test('version conflict requiring directory duplication', async () => {
+  test('version conflict requiring directory duplication', () => {
     //      ROOT
     //       /|\
     //      / | \
@@ -242,7 +242,7 @@ suite('NodeModulesLayoutMaker', () => {
     checkLayout(rootDeps, depGraph, expected);
   });
 
-  test('short loop', async () => {
+  test('short loop', () => {
     //   ROOT --> A1 --> B1
     //             ^     |
     //             |     |
@@ -264,7 +264,7 @@ suite('NodeModulesLayoutMaker', () => {
     checkLayout(rootDeps, depGraph, expected);
   });
 
-  test('longer loop on a branch', async () => {
+  test('longer loop on a branch', () => {
     //       ROOT
     //        /\
     //       /  \

--- a/src/typescript-worker/node-modules-layout-maker.ts
+++ b/src/typescript-worker/node-modules-layout-maker.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+type VersionNumber = string;
+
+/**
+ * Like the "dependencies" field of a package.json file, except the version
+ * numbers are always concrete instead of semver ranges.
+ */
+export interface PackageDependencies {
+  [pkg: string]: VersionNumber;
+}
+
+/**
+ * Maps from NPM package name, to the versions of that package, to its
+ * dependencies.
+ */
+export interface DependencyGraph {
+  [pkg: string]: {
+    [version: string]: PackageDependencies;
+  };
+}
+
+/**
+ * The contents of a "node_modules/" directory. Keys are NPM package names.
+ * Values are objects containing the version, and the contents of a nested
+ * "node_modules/" directory.
+ */
+export interface NodeModulesDirectory {
+  [pkg: string]: {
+    version: VersionNumber;
+    nodeModules: NodeModulesDirectory;
+  };
+}
+
+/**
+ * Temporary data structure used during graph traversal to associate a node in
+ * the dependency graph with its corresponding node_modules/ directory, and the
+ * parent of that directory.
+ */
+interface GraphTraversalState {
+  dependencies: PackageDependencies;
+  nodeModules: NodeModulesDirectory;
+  parent: GraphTraversalState | null;
+}
+
+/**
+ * Given an NPM-style dependency graph, makes a directory structure comprised of
+ * nested "node_modules/" folders that is compatible with the layout expected by
+ * the Node module resolution algorithm
+ * (https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders).
+ *
+ * Attempts to create the flattest directory layout possible to reduce file
+ * duplication, without causing version conflicts.
+ *
+ * For example, given the dependency graph:
+ *
+ *      ROOT
+ *       /|\
+ *      / | \
+ *     /  |  \
+ *    v   v   v
+ *    A1  B1  C1
+ *         \   /
+ *          \ /
+ *           v
+ *           A2 --> D1
+ *
+ * Returns the directory tree:
+ *
+ *   ROOT
+ *   ├── A1
+ *   ├── B1
+ *   │   └── A2
+ *   ├── C1
+ *   │   └── A2
+ *   └── D1
+ */
+export class NodeModulesLayoutMaker {
+  layout(
+    rootDeps: PackageDependencies,
+    depGraph: DependencyGraph
+  ): NodeModulesDirectory {
+    const rootNodeModulesDir: NodeModulesDirectory = {};
+    // Traverse the dependency graph using breadth-first search so that we
+    // "install" all of a package's direct dependencies before moving on to its
+    // transitive dependencies.
+    const bfsQueue: Array<GraphTraversalState> = [
+      {
+        dependencies: rootDeps,
+        nodeModules: rootNodeModulesDir,
+        parent: null,
+      },
+    ];
+    while (bfsQueue.length > 0) {
+      const currentNode = bfsQueue.shift()!;
+      for (const [pkg, version] of Object.entries(currentNode.dependencies)) {
+        // Find the best node_modules/ directory to install this dependency
+        // into. We're looking for the directory that is closest to the root
+        // (including the root itself), but which has no conflicting version of
+        // the same package along the path.
+        let installLocation = currentNode;
+        let alreadyInstalled = false;
+        while (installLocation.parent !== null) {
+          const parentVersion =
+            installLocation.parent.nodeModules[pkg]?.version;
+          if (parentVersion !== undefined) {
+            alreadyInstalled = parentVersion === version;
+            break;
+          }
+          installLocation = installLocation.parent;
+        }
+        if (alreadyInstalled) {
+          // This package was already installed at the exact same version in
+          // some reachable ancestor directory, so we're already done.
+          continue;
+        }
+        // "Install" this dependency.
+        const nestedNodeModules = {};
+        installLocation.nodeModules[pkg] = {
+          version,
+          nodeModules: nestedNodeModules,
+        };
+        // Add this dependency's own dependencies onto the breadth-first search
+        // queue.
+        const childDependencies = depGraph[pkg]?.[version];
+        if (childDependencies !== undefined) {
+          bfsQueue.push({
+            dependencies: childDependencies,
+            nodeModules: nestedNodeModules,
+            parent: installLocation,
+          });
+        }
+      }
+    }
+    return rootNodeModulesDir;
+  }
+}


### PR DESCRIPTION
This class will be used in a follow-up PR to solve a problem we currently have with the TypeScript type-checker step. Currently, if there are multiple conflicting versions of the same package in a project's transitive NPM dependency graph, we
load the `.d.ts` files from an _arbitrary_ version among those. This happens because the virtual filesystem we present to TypeScript is a completely _flat_ `node_modules/` directory, with no distinction between versions (whichever version to load last currently wins). This class will let us instead preset *nested* `node_modules/` directories to TypeScript, just like what NPM does when installing locally, so that every file gets the correct version of the typings it depends on.

---

Given an NPM-style dependency graph, this new class makes a directory structure comprised of nested `node_modules/` folders that is compatible with the layout expected by the Node module resolution algorithm (https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders).

It attempts to create the flattest directory layout possible, to reduce file duplication, without causing version conflicts.

For example, given the dependency graph:

```
     ROOT
      /|\
     / | \
    /  |  \
   v   v   v
   A1  B1  C1
        \   /
         \ /
          v
          A2 --> D1
```

Returns the directory tree:

```
  ROOT
  ├── A1
  ├── B1
  │   └── A2
  ├── C1
  │   └── A2
  └── D1
```