### PR TITLE
Creating a file that exists but is hidden now reveals the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- If a file is marked `hidden`, and the user creates a new file by that name,
+  the file will become visible and editable.
 
 ## [0.12.0] - 2021-08-17
 

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -533,22 +533,33 @@ export class PlaygroundProject extends LitElement {
   }
 
   isValidNewFilename(name: string): boolean {
-    return (
-      !!name && !!this._files && !this._files.some((file) => file.name === name)
-    );
+    if (!name) {
+      return false;
+    }
+    const existing = this._files?.find((file) => file.name === name);
+    if (existing !== undefined) {
+      return existing.hidden === true;
+    }
+    return true;
   }
 
   addFile(name: string) {
-    if (!this._files) {
+    if (!this._files || !this.isValidNewFilename(name)) {
       return;
     }
-    if (!this.isValidNewFilename(name)) {
-      return;
+    const existing = this._files?.find((file) => file.name === name);
+    if (existing?.hidden === true) {
+      // If a file already exists but is hidden, then we allow the user to
+      // "create" it, which is actually unhiding it.
+      existing.hidden = false;
+    } else {
+      this._files.push({
+        name,
+        content: '',
+        contentType: typeFromFilename(name),
+      });
     }
-    this._files = [
-      ...this._files,
-      {name, content: '', contentType: typeFromFilename(name)},
-    ];
+    this.requestUpdate();
     this.dispatchEvent(new CustomEvent('filesChanged'));
     this.save();
   }


### PR DESCRIPTION
If a file is marked hidden, then before this PR there was no way for the user to view or edit it. Creating a file with the same name was not allowed.

After this PR, then a user can reveal an existing hidden file by creating a file with the same name.

A little weird perhaps, but I think it's a decent solution. The motivating use case is that on lit.dev, we have a number of examples that have a `package.json` file pinning the project to the latest versions of Lit. However, we mark that `package.json` hidden so that it doesn't clutter up the list of files (especially when displayed as an inline sample). However, if a user wants to add a new dependency with a version constraint, or modify one of the existing Lit dependencies, there is currently no way to do it. Now, they'll be able to "create" a `package.json`, and then be able to see and modify the existing `package.json`.