### PR TITLE
Don't create a new languageservice on every build + incremental builds

### DIFF
--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -545,7 +545,6 @@ export class PlaygroundProject extends LitElement {
       return;
     }
     workerApi.compileProject(
-      this._sessionId,
       this._files ?? [],
       {importMap: this._importMap},
       proxy((result) => build.onOutput(result))

--- a/src/playground-project.ts
+++ b/src/playground-project.ts
@@ -545,6 +545,7 @@ export class PlaygroundProject extends LitElement {
       return;
     }
     workerApi.compileProject(
+      this._sessionId,
       this._files ?? [],
       {importMap: this._importMap},
       proxy((result) => build.onOutput(result))

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -74,7 +74,6 @@ export interface ServiceWorkerAPI {
 
 export interface TypeScriptWorkerAPI {
   compileProject(
-    projectId: string,
     files: Array<SampleFile>,
     config: {
       importMap: ModuleImportMap;

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -74,6 +74,7 @@ export interface ServiceWorkerAPI {
 
 export interface TypeScriptWorkerAPI {
   compileProject(
+    projectId: string,
     files: Array<SampleFile>,
     config: {
       importMap: ModuleImportMap;

--- a/src/shared/worker-api.ts
+++ b/src/shared/worker-api.ts
@@ -72,13 +72,15 @@ export interface ServiceWorkerAPI {
   setFileAPI(fileAPI: FileAPI, sessionID: string): void;
 }
 
+export interface TypeScriptWorkerConfig {
+    importMap: ModuleImportMap;
+    cdnBaseUrl?: string;
+}
+
 export interface TypeScriptWorkerAPI {
   compileProject(
     files: Array<SampleFile>,
-    config: {
-      importMap: ModuleImportMap;
-      cdnBaseUrl?: string;
-    },
+    config: TypeScriptWorkerConfig,
     emit: (result: BuildOutput) => void
   ): Promise<void>;
 }

--- a/src/test/worker-test-util.ts
+++ b/src/test/worker-test-util.ts
@@ -48,7 +48,7 @@ export const checkTransform = async (
           results.push(result);
         }
       };
-      build("11111", files, {importMap, cdnBaseUrl}, emit);
+      build(files, {importMap, cdnBaseUrl}, emit);
     });
 
     for (const result of results) {

--- a/src/test/worker-test-util.ts
+++ b/src/test/worker-test-util.ts
@@ -48,7 +48,7 @@ export const checkTransform = async (
           results.push(result);
         }
       };
-      build(files, {importMap, cdnBaseUrl}, emit);
+      build("11111", files, {importMap, cdnBaseUrl}, emit);
     });
 
     for (const result of results) {

--- a/src/typescript-worker/build.ts
+++ b/src/typescript-worker/build.ts
@@ -16,7 +16,6 @@ import {CachingCdn} from './caching-cdn.js';
 import { getBuilder } from './project-cache.js';
 
 export const build = async (
-  projectId: string,
   files: Array<SampleFile>,
   config: {
     importMap: ModuleImportMap;
@@ -26,7 +25,7 @@ export const build = async (
 ): Promise<void> => {
   const moduleResolver = new ImportMapResolver(config.importMap);
   const cdn = new CachingCdn(config.cdnBaseUrl ?? 'https://unpkg.com/');
-  const tsBuilder = getBuilder(projectId, cdn, moduleResolver);
+  const tsBuilder = getBuilder(cdn, moduleResolver);
   const bareModuleBuilder = new BareModuleTransformer(cdn, moduleResolver);
   const results = bareModuleBuilder.process(
     tsBuilder.process(files.map((file) => ({kind: 'file', file})))

--- a/src/typescript-worker/build.ts
+++ b/src/typescript-worker/build.ts
@@ -9,23 +9,20 @@ import {ImportMapResolver} from './import-map-resolver.js';
 
 import type {
   SampleFile,
-  ModuleImportMap,
   BuildOutput,
+  TypeScriptWorkerConfig,
 } from '../shared/worker-api.js';
 import {CachingCdn} from './caching-cdn.js';
-import { getBuilder } from './project-cache.js';
+import {getBuilder} from './project-cache.js';
 
 export const build = async (
   files: Array<SampleFile>,
-  config: {
-    importMap: ModuleImportMap;
-    cdnBaseUrl?: string;
-  },
+  config: TypeScriptWorkerConfig,
   emit: (result: BuildOutput) => void
 ): Promise<void> => {
   const moduleResolver = new ImportMapResolver(config.importMap);
   const cdn = new CachingCdn(config.cdnBaseUrl ?? 'https://unpkg.com/');
-  const tsBuilder = getBuilder(cdn, moduleResolver);
+  const tsBuilder = getBuilder(config, cdn, moduleResolver);
   const bareModuleBuilder = new BareModuleTransformer(cdn, moduleResolver);
   const results = bareModuleBuilder.process(
     tsBuilder.process(files.map((file) => ({kind: 'file', file})))

--- a/src/typescript-worker/build.ts
+++ b/src/typescript-worker/build.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {TypeScriptBuilder} from './typescript.js';
 import {BareModuleTransformer} from './bare-module-transformer.js';
 import {ImportMapResolver} from './import-map-resolver.js';
 
@@ -14,8 +13,10 @@ import type {
   BuildOutput,
 } from '../shared/worker-api.js';
 import {CachingCdn} from './caching-cdn.js';
+import { getBuilder } from './project-cache.js';
 
 export const build = async (
+  projectId: string,
   files: Array<SampleFile>,
   config: {
     importMap: ModuleImportMap;
@@ -23,9 +24,10 @@ export const build = async (
   },
   emit: (result: BuildOutput) => void
 ): Promise<void> => {
+    console.log({files, config, emit, projectId})
   const moduleResolver = new ImportMapResolver(config.importMap);
   const cdn = new CachingCdn(config.cdnBaseUrl ?? 'https://unpkg.com/');
-  const tsBuilder = new TypeScriptBuilder(cdn, moduleResolver);
+  const tsBuilder = getBuilder(projectId, cdn, moduleResolver);
   const bareModuleBuilder = new BareModuleTransformer(cdn, moduleResolver);
   const results = bareModuleBuilder.process(
     tsBuilder.process(files.map((file) => ({kind: 'file', file})))

--- a/src/typescript-worker/build.ts
+++ b/src/typescript-worker/build.ts
@@ -24,7 +24,6 @@ export const build = async (
   },
   emit: (result: BuildOutput) => void
 ): Promise<void> => {
-    console.log({files, config, emit, projectId})
   const moduleResolver = new ImportMapResolver(config.importMap);
   const cdn = new CachingCdn(config.cdnBaseUrl ?? 'https://unpkg.com/');
   const tsBuilder = getBuilder(projectId, cdn, moduleResolver);

--- a/src/typescript-worker/project-cache.ts
+++ b/src/typescript-worker/project-cache.ts
@@ -3,13 +3,12 @@ import {CachingCdn} from './caching-cdn.js';
 import { ImportMapResolver } from "./import-map-resolver";
 
 
-export const builderCache = new Map();
+export let builderInstance: TypeScriptBuilder;
 
-export function getBuilder(projectId: string, cdn: CachingCdn, moduleResolver: ImportMapResolver) {
-  if (builderCache.has(projectId)) {
-    return builderCache.get(projectId);
+export function getBuilder(cdn: CachingCdn, moduleResolver: ImportMapResolver) {
+  if (builderInstance) {
+    return builderInstance;
   }
-  const tsBuilder = new TypeScriptBuilder(cdn, moduleResolver);
-  builderCache.set(projectId, tsBuilder);
-  return tsBuilder;
+  builderInstance = new TypeScriptBuilder(cdn, moduleResolver);
+  return builderInstance;
 }

--- a/src/typescript-worker/project-cache.ts
+++ b/src/typescript-worker/project-cache.ts
@@ -1,14 +1,33 @@
-import { TypeScriptBuilder } from "./typescript";
-import {CachingCdn} from './caching-cdn.js';
-import { ImportMapResolver } from "./import-map-resolver";
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
+import {TypeScriptBuilder} from './typescript';
+import {CachingCdn} from './caching-cdn.js';
+import {ImportMapResolver} from './import-map-resolver';
+import {TypeScriptWorkerConfig} from '../shared/worker-api';
 
 export let builderInstance: TypeScriptBuilder;
+let cacheKey: string = '';
 
-export function getBuilder(cdn: CachingCdn, moduleResolver: ImportMapResolver) {
-  if (builderInstance) {
+/**
+ * Acquire the existing builder instance, or create a fresh one if missing.
+ * If the config differs from the existing instance's config, a new TypeScriptBuilder is
+ * instantiated and made the new builderInstance.
+ */
+export function getBuilder(
+  config: TypeScriptWorkerConfig,
+  cdn: CachingCdn,
+  moduleResolver: ImportMapResolver
+) {
+  const configCacheKey = JSON.stringify(config);
+  if (builderInstance && cacheKey === configCacheKey) {
     return builderInstance;
   }
+
+  cacheKey = configCacheKey;
   builderInstance = new TypeScriptBuilder(cdn, moduleResolver);
   return builderInstance;
 }

--- a/src/typescript-worker/project-cache.ts
+++ b/src/typescript-worker/project-cache.ts
@@ -1,0 +1,15 @@
+import { TypeScriptBuilder } from "./typescript";
+import {CachingCdn} from './caching-cdn.js';
+import { ImportMapResolver } from "./import-map-resolver";
+
+
+export const builderCache = new Map();
+
+export function getBuilder(projectId: string, cdn: CachingCdn, moduleResolver: ImportMapResolver) {
+  if (builderCache.has(projectId)) {
+    return builderCache.get(projectId);
+  }
+  const tsBuilder = new TypeScriptBuilder(cdn, moduleResolver);
+  builderCache.set(projectId, tsBuilder);
+  return tsBuilder;
+}

--- a/src/typescript-worker/typescript.ts
+++ b/src/typescript-worker/typescript.ts
@@ -12,7 +12,6 @@ import type * as lsp from 'vscode-languageserver';
 import type {SampleFile, BuildOutput} from '../shared/worker-api.js';
 import type {PackageJson} from './util.js';
 import type {CachingCdn} from './caching-cdn.js';
-import {LanguageService} from 'typescript';
 
 const compilerOptions = {
   target: ts.ScriptTarget.ES2017,
@@ -38,10 +37,12 @@ export class TypeScriptBuilder {
   private readonly _cdn: CachingCdn;
   private readonly _importMapResolver: ImportMapResolver;
 
-  private readonly _languageServiceHost: WorkerLanguageServiceHost =
-    new WorkerLanguageServiceHost(self.origin, compilerOptions);
+  private readonly _languageServiceHost = new WorkerLanguageServiceHost(
+    self.origin,
+    compilerOptions
+  );
 
-  private _languageService: LanguageService = ts.createLanguageService(
+  private readonly _languageService = ts.createLanguageService(
     this._languageServiceHost,
     ts.createDocumentRegistry()
   );
@@ -136,9 +137,7 @@ export class TypeScriptBuilder {
       // TypeScript is going to look for these files as paths relative to our
       // source files, so we need to add them to our filesystem with those URLs.
       const url = new URL(`node_modules/${path}`, self.origin).href;
-      if (!this._languageServiceHost?.fileExists(url)) {
-        this._languageServiceHost?.addFile(url, {content, version: 0});
-      }
+      this._languageServiceHost.updateFileContentIfNeeded(url, content);
     }
     for (const {file, url} of inputFiles) {
       for (const tsDiagnostic of this._languageService.getSemanticDiagnostics(
@@ -162,16 +161,11 @@ interface VersionedFile {
 class WorkerLanguageServiceHost implements ts.LanguageServiceHost {
   readonly compilerOptions: ts.CompilerOptions;
   readonly packageRoot: string;
-  readonly files: Map<string, VersionedFile>;
+  readonly files: Map<string, VersionedFile> = new Map<string, VersionedFile>();
 
-  constructor(
-    packageRoot: string,
-    compilerOptions: ts.CompilerOptions,
-    files?: Map<string, VersionedFile>
-  ) {
+  constructor(packageRoot: string, compilerOptions: ts.CompilerOptions) {
     this.packageRoot = packageRoot;
     this.compilerOptions = compilerOptions;
-    this.files = files || new Map();
   }
 
   /*
@@ -185,11 +179,11 @@ class WorkerLanguageServiceHost implements ts.LanguageServiceHost {
    */
   updateFileContentIfNeeded(fileName: string, content: string) {
     const file = this.files.get(fileName);
-    if (file && this._fileContentHasUpdated(file, content)) {
+    if (file && file.content !== content) {
       file.content = content;
       file.version += 1;
     } else {
-      this.addFile(fileName, {content, version: 0});
+      this.files.set(fileName, {content, version: 0});
     }
   }
 
@@ -203,33 +197,15 @@ class WorkerLanguageServiceHost implements ts.LanguageServiceHost {
     files.forEach((file, fileName) =>
       this.updateFileContentIfNeeded(fileName, file)
     );
-    this.removeDeletedFiles(files);
+    this._removeDeletedFiles(files);
   }
 
-  removeDeletedFiles(files: Map<string, string>) {
+  private _removeDeletedFiles(files: Map<string, string>) {
     this.getScriptFileNames().forEach((fileName) => {
       if (!files.has(fileName)) {
-        this.removeFile(fileName);
+        this.files.delete(fileName);
       }
     });
-  }
-
-  addFile(fileName: string, file: VersionedFile) {
-    this.files.set(fileName, file);
-  }
-
-  addFiles(files: Map<string, VersionedFile>) {
-    files.forEach((file, fileName) => {
-      this.files.set(fileName, file);
-    });
-  }
-
-  removeFile(fileName: string) {
-    this.files.delete(fileName);
-  }
-
-  _fileContentHasUpdated(oldFile: VersionedFile, newContent: string) {
-    return oldFile?.content !== newContent;
   }
 
   getCompilationSettings(): ts.CompilerOptions {


### PR DESCRIPTION
Heya,

As per our discussion here and on slack, I've fiddled around with the code base a bit.

I did a simple map-based "cache" for the typescript builders, saving them by project id's and rewrote the way we handled the languageservices.

I made the now cached instance of TypescriptBuilder save the languageService and the languageServiceHost as class level properties, so that we can re-use them instead of instantiating a new one every build.

I also expanded the WorkerLanguageServiceHost class to handle the new way of adding, and syncing the project files. Now with the added versioning, we can just update the necessary files, and by bumping up the version number on those files, the languageservice will be able to incrementally build them.


A lot of inspiration was drawn from the [TS docs](https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#incremental-build-support-using-the-language-services). I'd love to have a review on this and if this is going in the right direction?

From my local testing, everything should work as it did before, just a bit snappier and more efficiently.

If this change and coding style is fine, I'd love to delve deeper into the actual language service support and integrating more LSP features to the playground.