### PR TITLE
Skip setting file to language service if exists and has not changed

### DIFF
--- a/src/typescript-worker/language-service-context.ts
+++ b/src/typescript-worker/language-service-context.ts
@@ -67,13 +67,13 @@ class WorkerLanguageServiceHost implements ts.LanguageServiceHost {
   updateFileContentIfNeeded(fileName: string, content: string) {
     const file = this.files.get(fileName);
     if (file) {
-        if (file.content === content) {
-            // The file hasn't changed, exit early.
-            return;
-        }
-        file.content = content;
-        file.version += 1;
+      if (file.content === content) {
+        // The file hasn't changed, exit early.
         return;
+      }
+      file.content = content;
+      file.version += 1;
+      return;
     }
 
     this.files.set(fileName, {content, version: 0});

--- a/src/typescript-worker/language-service-context.ts
+++ b/src/typescript-worker/language-service-context.ts
@@ -66,12 +66,17 @@ class WorkerLanguageServiceHost implements ts.LanguageServiceHost {
    */
   updateFileContentIfNeeded(fileName: string, content: string) {
     const file = this.files.get(fileName);
-    if (file && file.content !== content) {
-      file.content = content;
-      file.version += 1;
-    } else {
-      this.files.set(fileName, {content, version: 0});
+    if (file) {
+        if (file.content === content) {
+            // The file hasn't changed, exit early.
+            return;
+        }
+        file.content = content;
+        file.version += 1;
+        return;
     }
+
+    this.files.set(fileName, {content, version: 0});
   }
 
   /**


### PR DESCRIPTION
A small bug that had slipped through the reviews in type language service rework.

Old implementation ran `this.files.set` every time a file was found, but wasn't modified. To reduce unnecessary map access, we just early return if..

- A file is already in the language service host
- But isn't updated.