### PR TITLE
Allow diagnostic and completions in js

### DIFF
--- a/src/playground-code-editor.ts
+++ b/src/playground-code-editor.ts
@@ -632,7 +632,7 @@ export class PlaygroundCodeEditor extends LitElement {
   private _currentFiletypeSupportsCompletion() {
     // Currently we are only supporting code completion for TS. Change
     // this in a case that we start to support it for other languages too.
-    return this.type === 'ts';
+    return this.type === 'ts' || this.type === 'js';
   }
 
   override focus() {

--- a/src/typescript-worker/language-service-context.ts
+++ b/src/typescript-worker/language-service-context.ts
@@ -13,6 +13,7 @@ const compilerOptions = {
   skipDefaultLibCheck: true,
   skipLibCheck: true,
   allowJs: true,
+  checkJs: true,
   moduleResolution: ts.ModuleResolutionKind.NodeJs,
   jsx: ts.JsxEmit.React,
   lib: ['dom', 'esnext'],

--- a/src/typescript-worker/language-service-context.ts
+++ b/src/typescript-worker/language-service-context.ts
@@ -67,13 +67,13 @@ class WorkerLanguageServiceHost implements ts.LanguageServiceHost {
   updateFileContentIfNeeded(fileName: string, content: string) {
     const file = this.files.get(fileName);
     if (file) {
-        if (file.content === content) {
-            // The file hasn't changed, exit early.
-            return;
-        }
-        file.content = content;
-        file.version += 1;
+      if (file.content === content) {
+        // The file hasn't changed, exit early.
         return;
+      }
+      file.content = content;
+      file.version += 1;
+      return;
     }
 
     this.files.set(fileName, {content, version: 0});

--- a/src/typescript-worker/language-service-context.ts
+++ b/src/typescript-worker/language-service-context.ts
@@ -66,12 +66,17 @@ class WorkerLanguageServiceHost implements ts.LanguageServiceHost {
    */
   updateFileContentIfNeeded(fileName: string, content: string) {
     const file = this.files.get(fileName);
-    if (file && file.content !== content) {
-      file.content = content;
-      file.version += 1;
-    } else {
-      this.files.set(fileName, {content, version: 0});
+    if (file) {
+        if (file.content === content) {
+            // The file hasn't changed, exit early.
+            return;
+        }
+        file.content = content;
+        file.version += 1;
+        return;
     }
+
+    this.files.set(fileName, {content, version: 0});
   }
 
   /**


### PR DESCRIPTION
This PR builds on top of https://github.com/google/playground-elements/pull/336 since the optimization was kind of needed for some of the code changes here too.

If this gets merged, we don't need to merge https://github.com/google/playground-elements/pull/336 since this was branched from it and the commit is here too.

The PR is quite simple in general: We just add JS as the allowed filetype in a couple of places and inform TS that javascript files should also be handled.

Then instead of just yielding the JS files in `processTypeScriptFiles` we also add it to the compilerinputs. It will make it so that they are handled in the completions and diagnostics parts of our code, but the won't try to compile them since they're already javascript.